### PR TITLE
don't recreate load balancers when resource_id changes

### DIFF
--- a/azurem/modules/load_balancers/main.tf
+++ b/azurem/modules/load_balancers/main.tf
@@ -22,6 +22,16 @@ resource "kubernetes_service" "console_load_balancer" {
   }
 
   wait_for_load_balancer = true
+
+  lifecycle {
+    ignore_changes = [
+      # The resource_id is known only after apply,
+      # so terraform wants to destroy the resource
+      # on any changes to the Materialize CR.
+      metadata[0].name,
+      spec[0].selector["materialize.cloud/name"],
+    ]
+  }
 }
 
 resource "kubernetes_service" "balancerd_load_balancer" {
@@ -54,4 +64,14 @@ resource "kubernetes_service" "balancerd_load_balancer" {
   }
 
   wait_for_load_balancer = true
+
+  lifecycle {
+    ignore_changes = [
+      # The resource_id is known only after apply,
+      # so terraform wants to destroy the resource
+      # on any changes to the Materialize CR.
+      metadata[0].name,
+      spec[0].selector["materialize.cloud/name"],
+    ]
+  }
 }

--- a/gcp/modules/load_balancers/main.tf
+++ b/gcp/modules/load_balancers/main.tf
@@ -23,6 +23,11 @@ resource "kubernetes_service" "console_load_balancer" {
 
   lifecycle {
     ignore_changes = [
+      # The resource_id is known only after apply,
+      # so terraform wants to destroy the resource
+      # on any changes to the Materialize CR.
+      metadata[0].name,
+      spec[0].selector["materialize.cloud/name"],
       metadata[0].annotations["cloud.google.com/neg"]
     ]
   }
@@ -60,6 +65,11 @@ resource "kubernetes_service" "balancerd_load_balancer" {
 
   lifecycle {
     ignore_changes = [
+      # The resource_id is known only after apply,
+      # so terraform wants to destroy the resource
+      # on any changes to the Materialize CR.
+      metadata[0].name,
+      spec[0].selector["materialize.cloud/name"],
       metadata[0].annotations["cloud.google.com/neg"]
     ]
   }


### PR DESCRIPTION
Don't recreate the load balancers when the resource_id "changes". The resource_id isn't actually changing, terraform just doesn't know that. The resource_id is unknown until apply time, so terraform makes a plan that destroys these dependent objects then recreates them exactly as they were.