### PR TITLE
switch to kubectl provider

### DIFF
--- a/aws/examples/simple/.terraform.lock.hcl
+++ b/aws/examples/simple/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/alekc/kubectl" {
+  version     = "2.1.3"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:AymCb0DCWzmyLqn1qEhVs2pcFUZGT/kxPK+I/BObFH8=",
+    "zh:0e601ae36ebc32eb8c10aff4c48c1125e471fa09f5668465af7581c9057fa22c",
+    "zh:1773f08a412d1a5f89bac174fe1efdfd255ecdda92d31a2e31937e4abf843a2f",
+    "zh:1da2db1f940c5d34e31c2384c7bd7acba68725cc1d3ba6db0fec42efe80dbfb7",
+    "zh:20dc810fb09031bcfea4f276e1311e8286d8d55705f55433598418b7bcc76357",
+    "zh:326a01c86ba90f6c6eb121bacaabb85cfa9059d6587aea935a9bbb6d3d8e3f3f",
+    "zh:5a3737ea1e08421fe3e700dc833c6fd2c7b8c3f32f5444e844b3fe0c2352757b",
+    "zh:5f490acbd0348faefea273cb358db24e684cbdcac07c71002ee26b6cfd2c54a0",
+    "zh:777688cda955213ba637e2ac6b1994e438a5af4d127a34ecb9bb010a8254f8a8",
+    "zh:7acc32371053592f55ee0bcbbc2f696a8466415dea7f4bc5a6573f03953fc926",
+    "zh:81f0108e2efe5ae71e651a8826b61d0ce6918811ccfdc0e5b81b2cfb0f7f57fe",
+    "zh:88b785ea7185720cf40679cb8fa17e57b8b07fd6322cf2d4000b835282033d81",
+    "zh:89d833336b5cd027e671b46f9c5bc7d10c5109e95297639bbec8001da89aa2f7",
+    "zh:df108339a89d4372e5b13f77bd9d53c02a04362fb5d85e1d9b6b47292e30821c",
+    "zh:e8a2e3a5c50ca124e6014c361d72a9940d8e815f37ae2d1e9487ac77c3043013",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.99.1"
   constraints = ">= 4.33.0, ~> 5.0, >= 5.79.0, >= 5.92.0, >= 5.95.0, < 6.0.0"
@@ -111,7 +133,7 @@ provider "registry.terraform.io/hashicorp/null" {
 
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.7.2"
-  constraints = "~> 3.0, >= 3.1.0"
+  constraints = "~> 3.0, >= 3.1.0, ~> 3.1"
   hashes = [
     "h1:356j/3XnXEKr9nyicLUufzoF4Yr6hRy481KIxRVpK0c=",
     "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
@@ -176,6 +198,7 @@ provider "registry.terraform.io/isometry/deepmerge" {
   version     = "1.1.0"
   constraints = "~> 1.0"
   hashes = [
+    "h1:NS/J39I/Nz0rmE7+2YVKh7GtZ1yL7Bym6Gw+XtftNGM=",
     "h1:TBxrJfAjo9+xw9vSqzIObqYc7Eljs39AmyBrNmIvdRA=",
     "zh:2f2740a211804df959835089cbac1b8b205c69ceaeac11c573bbac3a244f185d",
     "zh:43c478dae7c2cebf247d0511b4c0551570d2895035eb503f59e013b652ba8b8c",

--- a/aws/examples/simple/outputs.tf
+++ b/aws/examples/simple/outputs.tf
@@ -95,36 +95,38 @@ output "operator" {
 
 output "materialize_instance_name" {
   description = "Materialize instance name"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].instance_name : null
+  value       = module.materialize_instance.instance_name
 }
 
 output "materialize_instance_namespace" {
   description = "Materialize instance namespace"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].instance_namespace : null
+  value       = module.materialize_instance.instance_namespace
 }
 
 output "materialize_instance_resource_id" {
   description = "Materialize instance resource ID"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].instance_resource_id : null
+  value       = module.materialize_instance.instance_resource_id
 }
 
 output "materialize_instance_metadata_backend_url" {
   description = "Materialize instance metadata backend URL"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].metadata_backend_url : null
+  value       = module.materialize_instance.metadata_backend_url
   sensitive   = true
 }
 
 output "materialize_instance_persist_backend_url" {
   description = "Materialize instance persist backend URL"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].persist_backend_url : null
+  value       = module.materialize_instance.persist_backend_url
   sensitive   = true
 }
 
 # Load balancer outputs
-output "nlb_details" {
-  description = "Details of the Materialize instance NLBs."
-  value = {
-    arn      = try(module.materialize_nlb[0].nlb_arn, null)
-    dns_name = try(module.materialize_nlb[0].nlb_dns_name, null)
-  }
+output "nlb_arn" {
+  description = "ARN of the Materialize NLB."
+  value       = module.materialize_nlb.nlb_arn
+}
+
+output "nlb_dns_name" {
+  description = "DNS name of the Materialize NLB."
+  value       = module.materialize_nlb.nlb_dns_name
 }

--- a/aws/examples/simple/variables.tf
+++ b/aws/examples/simple/variables.tf
@@ -19,12 +19,6 @@ variable "name_prefix" {
   type        = string
 }
 
-variable "install_materialize_instance" {
-  description = "Whether to install the Materialize instance. Default is false as it requires the Kubernetes cluster to be created first."
-  type        = bool
-  default     = false
-}
-
 variable "license_key" {
   description = "Materialize license key"
   type        = string

--- a/aws/examples/simple/versions.tf
+++ b/aws/examples/simple/versions.tf
@@ -22,5 +22,9 @@ terraform {
       source  = "isometry/deepmerge"
       version = "~> 1.0"
     }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "~> 2.0"
+    }
   }
 }

--- a/aws/modules/nlb/target/main.tf
+++ b/aws/modules/nlb/target/main.tf
@@ -36,8 +36,8 @@ resource "aws_lb_listener" "listener" {
   }
 }
 
-resource "kubernetes_manifest" "target_group_binding" {
-  manifest = {
+resource "kubectl_manifest" "target_group_binding" {
+  yaml_body = jsonencode({
     "apiVersion" = "elbv2.k8s.aws/v1beta1"
     "kind"       = "TargetGroupBinding"
     "metadata" = {
@@ -51,13 +51,11 @@ resource "kubernetes_manifest" "target_group_binding" {
       }
       "targetGroupARN" = aws_lb_target_group.target_group.arn
     }
-  }
+  })
 
-  lifecycle {
-    ignore_changes = [
-      manifest.spec.serviceRef.name,
-    ]
-  }
+  ignore_fields = [
+    "spec.serviceRef.name",
+  ]
 
   depends_on = [
     aws_lb_listener.listener,

--- a/aws/modules/nlb/target/versions.tf
+++ b/aws/modules/nlb/target/versions.tf
@@ -18,5 +18,9 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "~> 2.0"
+    }
   }
 }

--- a/azurem/examples/simple/.terraform.lock.hcl
+++ b/azurem/examples/simple/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/alekc/kubectl" {
+  version     = "2.1.3"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:AymCb0DCWzmyLqn1qEhVs2pcFUZGT/kxPK+I/BObFH8=",
+    "zh:0e601ae36ebc32eb8c10aff4c48c1125e471fa09f5668465af7581c9057fa22c",
+    "zh:1773f08a412d1a5f89bac174fe1efdfd255ecdda92d31a2e31937e4abf843a2f",
+    "zh:1da2db1f940c5d34e31c2384c7bd7acba68725cc1d3ba6db0fec42efe80dbfb7",
+    "zh:20dc810fb09031bcfea4f276e1311e8286d8d55705f55433598418b7bcc76357",
+    "zh:326a01c86ba90f6c6eb121bacaabb85cfa9059d6587aea935a9bbb6d3d8e3f3f",
+    "zh:5a3737ea1e08421fe3e700dc833c6fd2c7b8c3f32f5444e844b3fe0c2352757b",
+    "zh:5f490acbd0348faefea273cb358db24e684cbdcac07c71002ee26b6cfd2c54a0",
+    "zh:777688cda955213ba637e2ac6b1994e438a5af4d127a34ecb9bb010a8254f8a8",
+    "zh:7acc32371053592f55ee0bcbbc2f696a8466415dea7f4bc5a6573f03953fc926",
+    "zh:81f0108e2efe5ae71e651a8826b61d0ce6918811ccfdc0e5b81b2cfb0f7f57fe",
+    "zh:88b785ea7185720cf40679cb8fa17e57b8b07fd6322cf2d4000b835282033d81",
+    "zh:89d833336b5cd027e671b46f9c5bc7d10c5109e95297639bbec8001da89aa2f7",
+    "zh:df108339a89d4372e5b13f77bd9d53c02a04362fb5d85e1d9b6b47292e30821c",
+    "zh:e8a2e3a5c50ca124e6014c361d72a9940d8e815f37ae2d1e9487ac77c3043013",
+  ]
+}
+
 provider "registry.terraform.io/azure/azapi" {
   version     = "2.6.0"
   constraints = "~> 2.0, ~> 2.4, ~> 2.5"
@@ -173,6 +195,7 @@ provider "registry.terraform.io/isometry/deepmerge" {
   version     = "1.1.0"
   constraints = "~> 1.0"
   hashes = [
+    "h1:NS/J39I/Nz0rmE7+2YVKh7GtZ1yL7Bym6Gw+XtftNGM=",
     "h1:TBxrJfAjo9+xw9vSqzIObqYc7Eljs39AmyBrNmIvdRA=",
     "zh:2f2740a211804df959835089cbac1b8b205c69ceaeac11c573bbac3a244f185d",
     "zh:43c478dae7c2cebf247d0511b4c0551570d2895035eb503f59e013b652ba8b8c",

--- a/azurem/examples/simple/outputs.tf
+++ b/azurem/examples/simple/outputs.tf
@@ -106,37 +106,39 @@ output "operator" {
 
 output "materialize_instance_name" {
   description = "Materialize instance name"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].instance_name : null
+  value       = module.materialize_instance.instance_name
 }
 
 output "materialize_instance_namespace" {
   description = "Materialize instance namespace"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].instance_namespace : null
+  value       = module.materialize_instance.instance_namespace
 }
 
 output "materialize_instance_resource_id" {
   description = "Materialize instance resource ID"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].instance_resource_id : null
+  value       = module.materialize_instance.instance_resource_id
 }
 
 output "materialize_instance_metadata_backend_url" {
   description = "Materialize instance metadata backend URL"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].metadata_backend_url : null
+  value       = module.materialize_instance.metadata_backend_url
   sensitive   = true
 }
 
 output "materialize_instance_persist_backend_url" {
   description = "Materialize instance persist backend URL"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].persist_backend_url : null
+  value       = module.materialize_instance.persist_backend_url
 }
 
 # Load balancer outputs
-output "load_balancer_details" {
-  description = "Details of the Materialize instance load balancers."
-  value = {
-    console_load_balancer_ip   = try(module.load_balancers[0].console_load_balancer_ip, null)
-    balancerd_load_balancer_ip = try(module.load_balancers[0].balancerd_load_balancer_ip, null)
-  }
+output "console_load_balancer_ip" {
+  description = "IP address of the Materialize console's load balancer."
+  value       = module.load_balancers.console_load_balancer_ip
+}
+
+output "balancerd_load_balancer_ip" {
+  description = "IP address of the Materialize balancerd's load balancer."
+  value       = module.load_balancers.balancerd_load_balancer_ip
 }
 
 # Azure-specific outputs

--- a/azurem/examples/simple/variables.tf
+++ b/azurem/examples/simple/variables.tf
@@ -24,12 +24,6 @@ variable "tags" {
   type        = map(string)
 }
 
-variable "install_materialize_instance" {
-  description = "Whether to install the Materialize instance. Default is false as it requires the Kubernetes cluster to be created first."
-  type        = bool
-  default     = false
-}
-
 variable "license_key" {
   description = "Materialize license key"
   type        = string

--- a/azurem/examples/simple/versions.tf
+++ b/azurem/examples/simple/versions.tf
@@ -22,5 +22,9 @@ terraform {
       source  = "isometry/deepmerge"
       version = "~> 1.0"
     }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "~> 2.0"
+    }
   }
 }

--- a/gcp/examples/simple/.terraform.lock.hcl
+++ b/gcp/examples/simple/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/alekc/kubectl" {
+  version     = "2.1.3"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:AymCb0DCWzmyLqn1qEhVs2pcFUZGT/kxPK+I/BObFH8=",
+    "zh:0e601ae36ebc32eb8c10aff4c48c1125e471fa09f5668465af7581c9057fa22c",
+    "zh:1773f08a412d1a5f89bac174fe1efdfd255ecdda92d31a2e31937e4abf843a2f",
+    "zh:1da2db1f940c5d34e31c2384c7bd7acba68725cc1d3ba6db0fec42efe80dbfb7",
+    "zh:20dc810fb09031bcfea4f276e1311e8286d8d55705f55433598418b7bcc76357",
+    "zh:326a01c86ba90f6c6eb121bacaabb85cfa9059d6587aea935a9bbb6d3d8e3f3f",
+    "zh:5a3737ea1e08421fe3e700dc833c6fd2c7b8c3f32f5444e844b3fe0c2352757b",
+    "zh:5f490acbd0348faefea273cb358db24e684cbdcac07c71002ee26b6cfd2c54a0",
+    "zh:777688cda955213ba637e2ac6b1994e438a5af4d127a34ecb9bb010a8254f8a8",
+    "zh:7acc32371053592f55ee0bcbbc2f696a8466415dea7f4bc5a6573f03953fc926",
+    "zh:81f0108e2efe5ae71e651a8826b61d0ce6918811ccfdc0e5b81b2cfb0f7f57fe",
+    "zh:88b785ea7185720cf40679cb8fa17e57b8b07fd6322cf2d4000b835282033d81",
+    "zh:89d833336b5cd027e671b46f9c5bc7d10c5109e95297639bbec8001da89aa2f7",
+    "zh:df108339a89d4372e5b13f77bd9d53c02a04362fb5d85e1d9b6b47292e30821c",
+    "zh:e8a2e3a5c50ca124e6014c361d72a9940d8e815f37ae2d1e9487ac77c3043013",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/google" {
   version     = "6.46.0"
   constraints = ">= 3.33.0, >= 3.83.0, >= 4.25.0, >= 4.51.0, >= 4.64.0, >= 6.19.0, >= 6.31.0, < 7.0.0"
@@ -131,6 +153,7 @@ provider "registry.terraform.io/isometry/deepmerge" {
   version     = "1.1.0"
   constraints = "~> 1.0"
   hashes = [
+    "h1:NS/J39I/Nz0rmE7+2YVKh7GtZ1yL7Bym6Gw+XtftNGM=",
     "h1:TBxrJfAjo9+xw9vSqzIObqYc7Eljs39AmyBrNmIvdRA=",
     "zh:2f2740a211804df959835089cbac1b8b205c69ceaeac11c573bbac3a244f185d",
     "zh:43c478dae7c2cebf247d0511b4c0551570d2895035eb503f59e013b652ba8b8c",

--- a/gcp/examples/simple/outputs.tf
+++ b/gcp/examples/simple/outputs.tf
@@ -105,38 +105,38 @@ output "operator" {
 
 output "materialize_instance_name" {
   description = "Materialize instance name"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].instance_name : null
+  value       = module.materialize_instance.instance_name
 }
 
 output "materialize_instance_namespace" {
   description = "Materialize instance namespace"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].instance_namespace : null
+  value       = module.materialize_instance.instance_namespace
 }
 
 output "materialize_instance_resource_id" {
   description = "Materialize instance resource ID"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].instance_resource_id : null
+  value       = module.materialize_instance.instance_resource_id
 }
 
 output "materialize_instance_metadata_backend_url" {
   description = "Materialize instance metadata backend URL"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].metadata_backend_url : null
+  value       = module.materialize_instance.metadata_backend_url
   sensitive   = true
 }
 
 output "materialize_instance_persist_backend_url" {
   description = "Materialize instance persist backend URL"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].persist_backend_url : null
+  value       = module.materialize_instance.persist_backend_url
   sensitive   = true
 }
 
 # Load balancer outputs
-output "load_balancer_details" {
-  description = "Details of the Materialize instance load balancers."
-  value = {
-    for load_balancer in module.load_balancers : load_balancer.instance_name => {
-      console_load_balancer_ip   = load_balancer.console_load_balancer_ip
-      balancerd_load_balancer_ip = load_balancer.balancerd_load_balancer_ip
-    }
-  }
+output "console_load_balancer_ip" {
+  description = "IP address of the Materialize console's load balancer."
+  value       = module.load_balancers.console_load_balancer_ip
+}
+
+output "balancerd_load_balancer_ip" {
+  description = "IP address of the Materialize balancerd's load balancer."
+  value       = module.load_balancers.balancerd_load_balancer_ip
 }

--- a/gcp/examples/simple/variables.tf
+++ b/gcp/examples/simple/variables.tf
@@ -20,12 +20,6 @@ variable "name_prefix" {
   default     = "materialize"
 }
 
-variable "install_materialize_instance" {
-  description = "Whether to install the Materialize instance. Default is false as it requires the Kubernetes cluster to be created first."
-  type        = bool
-  default     = false
-}
-
 variable "license_key" {
   description = "Materialize license key"
   type        = string

--- a/gcp/examples/simple/versions.tf
+++ b/gcp/examples/simple/versions.tf
@@ -22,5 +22,9 @@ terraform {
       source  = "isometry/deepmerge"
       version = "~> 1.0"
     }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "~> 2.0"
+    }
   }
 }

--- a/kubernetes/modules/materialize-instance/versions.tf
+++ b/kubernetes/modules/materialize-instance/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = ">= 2.10.0"
     }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "~> 2.0"
+    }
   }
 }

--- a/kubernetes/modules/self-signed-cluster-issuer/main.tf
+++ b/kubernetes/modules/self-signed-cluster-issuer/main.tf
@@ -1,5 +1,5 @@
-resource "kubernetes_manifest" "self_signed_cluster_issuer" {
-  manifest = {
+resource "kubectl_manifest" "self_signed_cluster_issuer" {
+  yaml_body = jsonencode({
     "apiVersion" = "cert-manager.io/v1"
     "kind"       = "ClusterIssuer"
     "metadata" = {
@@ -8,11 +8,11 @@ resource "kubernetes_manifest" "self_signed_cluster_issuer" {
     "spec" = {
       "selfSigned" = {}
     }
-  }
+  })
 }
 
-resource "kubernetes_manifest" "self_signed_root_ca_certificate" {
-  manifest = {
+resource "kubectl_manifest" "self_signed_root_ca_certificate" {
+  yaml_body = jsonencode({
     "apiVersion" = "cert-manager.io/v1"
     "kind"       = "Certificate"
     "metadata" = {
@@ -35,15 +35,15 @@ resource "kubernetes_manifest" "self_signed_root_ca_certificate" {
         "group" = "cert-manager.io"
       }
     }
-  }
+  })
 
   depends_on = [
-    kubernetes_manifest.self_signed_cluster_issuer,
+    kubectl_manifest.self_signed_cluster_issuer,
   ]
 }
 
-resource "kubernetes_manifest" "root_ca_cluster_issuer" {
-  manifest = {
+resource "kubectl_manifest" "root_ca_cluster_issuer" {
+  yaml_body = jsonencode({
     "apiVersion" = "cert-manager.io/v1"
     "kind"       = "ClusterIssuer"
     "metadata" = {
@@ -54,9 +54,9 @@ resource "kubernetes_manifest" "root_ca_cluster_issuer" {
         "secretName" = "${var.name_prefix}-root-ca"
       }
     }
-  }
+  })
 
   depends_on = [
-    kubernetes_manifest.self_signed_root_ca_certificate,
+    kubectl_manifest.self_signed_root_ca_certificate,
   ]
 }

--- a/kubernetes/modules/self-signed-cluster-issuer/outputs.tf
+++ b/kubernetes/modules/self-signed-cluster-issuer/outputs.tf
@@ -1,4 +1,4 @@
 output "issuer_name" {
   description = "Name of the ClusterIssuer"
-  value       = kubernetes_manifest.root_ca_cluster_issuer.object.metadata.name
+  value       = kubectl_manifest.root_ca_cluster_issuer.name
 }

--- a/kubernetes/modules/self-signed-cluster-issuer/versions.tf
+++ b/kubernetes/modules/self-signed-cluster-issuer/versions.tf
@@ -14,5 +14,9 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.1"
     }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "~> 2.0"
+    }
   }
 }

--- a/test/aws/fixtures/materialize/outputs.tf
+++ b/test/aws/fixtures/materialize/outputs.tf
@@ -149,14 +149,9 @@ output "operator_release_status" {
 # MATERIALIZE INSTANCE OUTPUTS
 # =============================================================================
 
-output "instance_installed" {
-  description = "Whether Materialize instance was installed"
-  value       = var.install_materialize_instance
-}
-
 output "instance_resource_id" {
   description = "Materialize instance resource ID"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].instance_resource_id : null
+  value       = module.materialize_instance.instance_resource_id
 }
 
 # =============================================================================
@@ -166,8 +161,8 @@ output "instance_resource_id" {
 output "nlb_details" {
   description = "Details of the Materialize instance NLBs."
   value = {
-    arn      = try(module.materialize_nlb[0].nlb_arn, null)
-    dns_name = try(module.materialize_nlb[0].nlb_dns_name, null)
+    arn      = try(module.materialize_nlb.nlb_arn, null)
+    dns_name = try(module.materialize_nlb.nlb_dns_name, null)
   }
 }
 
@@ -177,5 +172,5 @@ output "nlb_details" {
 
 output "cluster_issuer_name" {
   description = "Name of the cluster issuer"
-  value       = var.install_materialize_instance ? module.self_signed_cluster_issuer[0].issuer_name : null
+  value       = module.self_signed_cluster_issuer.issuer_name
 }

--- a/test/aws/fixtures/materialize/variables.tf
+++ b/test/aws/fixtures/materialize/variables.tf
@@ -186,11 +186,6 @@ variable "operator_namespace" {
   type        = string
 }
 
-variable "install_materialize_instance" {
-  description = "Flag to indicate if Materialize instance should be installed"
-  type        = bool
-}
-
 variable "instance_name" {
   description = "Name of the Materialize instance"
   type        = string

--- a/test/aws/fixtures/materialize/versions.tf
+++ b/test/aws/fixtures/materialize/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.8"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -12,6 +12,18 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    deepmerge = {
+      source  = "isometry/deepmerge"
+      version = "~> 1.0"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
       version = "~> 2.0"
     }
   }

--- a/test/aws/staged_deployment_test.go
+++ b/test/aws/staged_deployment_test.go
@@ -325,7 +325,6 @@ func (suite *StagedDeploymentTestSuite) setupMaterializeConsolidatedStage(stage,
 		"operator_namespace": expectedOperatorNamespace,
 
 		// Materialize Instance Configuration
-		"install_materialize_instance":      false,
 		"instance_name":                     fmt.Sprintf("%s-%s", resourceId, nameSuffix),
 		"instance_namespace":                expectedInstanceNamespace,
 		"external_login_password_mz_system": TestPassword,
@@ -362,15 +361,6 @@ func (suite *StagedDeploymentTestSuite) setupMaterializeConsolidatedStage(stage,
 
 	// Apply
 	terraform.InitAndApply(t, materializeOptions)
-
-	t.Logf("✅ Phase 1: Materialize operator installed on cluster where disk-enabled: %t", diskEnabled)
-
-	// Phase 2: Update terraform.tfvars.json file for instance deployment
-	variables["install_materialize_instance"] = true
-	helpers.CreateTfvarsFile(t, tfvarsPath, variables)
-
-	// Phase 2: Apply with instance enabled
-	terraform.Apply(t, materializeOptions)
 
 	// Validate all outputs from the consolidated fixture
 	t.Log("🔍 Validating all consolidated fixture outputs...")
@@ -412,7 +402,6 @@ func (suite *StagedDeploymentTestSuite) setupMaterializeConsolidatedStage(stage,
 	operatorReleaseStatus := terraform.Output(t, materializeOptions, "operator_release_status")
 
 	// Materialize Instance Outputs
-	instanceInstalled := terraform.Output(t, materializeOptions, "instance_installed")
 	instanceResourceId := terraform.Output(t, materializeOptions, "instance_resource_id")
 
 	// Network Load Balancer Outputs
@@ -462,7 +451,6 @@ func (suite *StagedDeploymentTestSuite) setupMaterializeConsolidatedStage(stage,
 	suite.NotEmpty(operatorReleaseStatus, "Operator release status should not be empty")
 
 	t.Log("✅ Validating Materialize Instance Outputs...")
-	suite.Equal("true", instanceInstalled, "Materialize instance should be installed")
 	suite.NotEmpty(instanceResourceId, "Materialize instance resource ID should not be empty")
 
 	t.Log("✅ Validating Network Load Balancer Outputs...")
@@ -472,7 +460,7 @@ func (suite *StagedDeploymentTestSuite) setupMaterializeConsolidatedStage(stage,
 	t.Log("✅ Validating Certificate Outputs...")
 	suite.NotEmpty(clusterIssuerName, "Cluster issuer name should not be empty")
 
-	t.Logf("✅ Phase 2: Complete Materialize stack created successfully:")
+	t.Logf("✅ Complete Materialize stack created successfully:")
 	t.Logf("  💾 Disk Enabled: %t", diskEnabled)
 
 	// EKS Cluster Outputs
@@ -519,7 +507,6 @@ func (suite *StagedDeploymentTestSuite) setupMaterializeConsolidatedStage(stage,
 
 	// Materialize Instance Outputs
 	t.Logf("🚀 MATERIALIZE INSTANCE OUTPUTS:")
-	t.Logf("  ✅ Instance Installed: %s", instanceInstalled)
 	t.Logf("  🆔 Instance Resource ID: %s", instanceResourceId)
 
 	// Network Load Balancer Outputs

--- a/test/azurem/fixtures/materialize/outputs.tf
+++ b/test/azurem/fixtures/materialize/outputs.tf
@@ -157,19 +157,14 @@ output "operator_namespace" {
 # MATERIALIZE INSTANCE OUTPUTS
 # =============================================================================
 
-output "instance_installed" {
-  description = "Whether the Materialize instance is installed"
-  value       = var.install_materialize_instance
-}
-
 output "instance_resource_id" {
   description = "The resource ID of the Materialize instance"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].instance_resource_id : null
+  value       = module.materialize_instance.instance_resource_id
 }
 
 output "external_login_password" {
   description = "The external login password for the Materialize instance"
-  value       = var.install_materialize_instance ? var.external_login_password_mz_system : null
+  value       = var.external_login_password_mz_system
   sensitive   = true
 }
 
@@ -177,19 +172,14 @@ output "external_login_password" {
 # LOAD BALANCER OUTPUTS
 # =============================================================================
 
-output "load_balancer_installed" {
-  description = "Whether the load balancer is installed"
-  value       = var.install_materialize_instance
-}
-
 output "console_load_balancer_ip" {
   description = "IP address of load balancer pointing at the web console"
-  value       = var.install_materialize_instance ? module.load_balancer[0].console_load_balancer_ip : null
+  value       = module.load_balancer.console_load_balancer_ip
 }
 
 output "balancerd_load_balancer_ip" {
   description = "IP address of load balancer pointing at balancerd"
-  value       = var.install_materialize_instance ? module.load_balancer[0].balancerd_load_balancer_ip : null
+  value       = module.load_balancer.balancerd_load_balancer_ip
 }
 
 # =============================================================================
@@ -198,5 +188,5 @@ output "balancerd_load_balancer_ip" {
 
 output "cluster_issuer_name" {
   description = "Name of the cluster issuer"
-  value       = var.install_materialize_instance ? module.self_signed_cluster_issuer[0].issuer_name : null
+  value       = module.self_signed_cluster_issuer.issuer_name
 }

--- a/test/azurem/fixtures/materialize/variables.tf
+++ b/test/azurem/fixtures/materialize/variables.tf
@@ -218,11 +218,6 @@ variable "operator_namespace" {
 }
 
 # Materialize Instance variables
-variable "install_materialize_instance" {
-  description = "Whether to install the Materialize instance"
-  type        = bool
-}
-
 variable "instance_name" {
   description = "The name of the Materialize instance"
   type        = string

--- a/test/azurem/fixtures/materialize/versions.tf
+++ b/test/azurem/fixtures/materialize/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.8"
 
   required_providers {
     azurerm = {
@@ -12,6 +12,18 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+    deepmerge = {
+      source  = "isometry/deepmerge"
+      version = "~> 1.0"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
       version = "~> 2.0"
     }
   }

--- a/test/azurem/staged_deployment_test.go
+++ b/test/azurem/staged_deployment_test.go
@@ -348,7 +348,6 @@ func (suite *StagedDeploymentSuite) setupMaterializeConsolidatedStage(stage, sta
 		"operator_namespace": expectedOperatorNamespace,
 
 		// Materialize Instance Configuration
-		"install_materialize_instance":      false,
 		"instance_name":                     TestMaterializeInstanceName,
 		"instance_namespace":                expectedInstanceNamespace,
 		"license_key":                       os.Getenv("MATERIALIZE_LICENSE_KEY"),
@@ -382,15 +381,6 @@ func (suite *StagedDeploymentSuite) setupMaterializeConsolidatedStage(stage, sta
 	// Apply
 	terraform.InitAndApply(t, materializeOptions)
 
-	t.Logf("✅ Phase 1: Materialize operator installed on cluster where disk-enabled: %t", diskEnabled)
-
-	// Phase 2: Update terraform.tfvars.json file for instance deployment
-	variables["install_materialize_instance"] = true
-	helpers.CreateTfvarsFile(t, tfvarsPath, variables)
-
-	// Phase 2: Apply with instance enabled
-	terraform.Apply(t, materializeOptions)
-
 	// Validate all outputs from the consolidated fixture
 	t.Log("🔍 Validating all consolidated fixture outputs...")
 
@@ -421,12 +411,10 @@ func (suite *StagedDeploymentSuite) setupMaterializeConsolidatedStage(stage, sta
 	operatorNamespace := terraform.Output(t, materializeOptions, "operator_namespace")
 
 	// Materialize Instance Outputs
-	instanceInstalled := terraform.Output(t, materializeOptions, "instance_installed")
 	instanceResourceId := terraform.Output(t, materializeOptions, "instance_resource_id")
 	externalLoginPassword := terraform.Output(t, materializeOptions, "external_login_password")
 
 	// Load Balancer Outputs
-	loadBalancerInstalled := terraform.Output(t, materializeOptions, "load_balancer_installed")
 	consoleLoadBalancerIP := terraform.Output(t, materializeOptions, "console_load_balancer_ip")
 	balancerdLoadBalancerIP := terraform.Output(t, materializeOptions, "balancerd_load_balancer_ip")
 
@@ -463,19 +451,17 @@ func (suite *StagedDeploymentSuite) setupMaterializeConsolidatedStage(stage, sta
 	suite.Equal(expectedOperatorNamespace, operatorNamespace, "Operator namespace should match expected value")
 
 	t.Log("✅ Validating Materialize Instance Outputs...")
-	suite.Equal("true", instanceInstalled, "Materialize instance should be installed")
 	suite.NotEmpty(instanceResourceId, "Materialize instance resource ID should not be empty")
 	suite.NotEmpty(externalLoginPassword, "External login password should not be empty")
 
 	t.Log("✅ Validating Load Balancer Outputs...")
-	suite.Equal("true", loadBalancerInstalled, "Load balancer should be installed")
 	suite.NotEmpty(consoleLoadBalancerIP, "Console load balancer IP should not be empty")
 	suite.NotEmpty(balancerdLoadBalancerIP, "Balancerd load balancer IP should not be empty")
 
 	t.Log("✅ Validating Certificate Outputs...")
 	suite.NotEmpty(clusterIssuerName, "Cluster issuer name should not be empty")
 
-	t.Logf("✅ Phase 2: Complete Materialize stack created successfully:")
+	t.Logf("✅ Complete Materialize stack created successfully:")
 	t.Logf("  💾 Disk Enabled: %t", diskEnabled)
 
 	// AKS Cluster Outputs
@@ -511,13 +497,11 @@ func (suite *StagedDeploymentSuite) setupMaterializeConsolidatedStage(stage, sta
 
 	// Materialize Instance Outputs
 	t.Logf("🚀 MATERIALIZE INSTANCE OUTPUTS:")
-	t.Logf("  ✅ Instance Installed: %s", instanceInstalled)
 	t.Logf("  🆔 Instance Resource ID: %s", instanceResourceId)
 	t.Logf("  🔐 External Login Password: [REDACTED]")
 
 	// Load Balancer Outputs
 	t.Logf("🌐 LOAD BALANCER OUTPUTS:")
-	t.Logf("  ✅ Load Balancer Installed: %s", loadBalancerInstalled)
 	t.Logf("  🌐 Console Load Balancer IP: %s", consoleLoadBalancerIP)
 	t.Logf("  🌐 Balancerd Load Balancer IP: %s", balancerdLoadBalancerIP)
 

--- a/test/gcp/fixtures/materialize/outputs.tf
+++ b/test/gcp/fixtures/materialize/outputs.tf
@@ -123,14 +123,9 @@ output "operator_namespace" {
 # MATERIALIZE INSTANCE OUTPUTS
 # =============================================================================
 
-output "instance_installed" {
-  description = "Whether Materialize instance was installed"
-  value       = var.install_materialize_instance
-}
-
 output "instance_resource_id" {
   description = "Materialize instance resource ID"
-  value       = var.install_materialize_instance ? module.materialize_instance[0].instance_resource_id : null
+  value       = module.materialize_instance.instance_resource_id
 }
 
 # =============================================================================
@@ -139,12 +134,12 @@ output "instance_resource_id" {
 
 output "console_load_balancer_ip" {
   description = "Console load balancer IP for external access"
-  value       = var.install_materialize_instance ? module.load_balancer[0].console_load_balancer_ip : null
+  value       = module.load_balancer.console_load_balancer_ip
 }
 
 output "balancerd_load_balancer_ip" {
   description = "Balancerd load balancer IP for external access"
-  value       = var.install_materialize_instance ? module.load_balancer[0].balancerd_load_balancer_ip : null
+  value       = module.load_balancer.balancerd_load_balancer_ip
 }
 
 # =============================================================================
@@ -153,5 +148,5 @@ output "balancerd_load_balancer_ip" {
 
 output "cluster_issuer_name" {
   description = "Name of the cluster issuer"
-  value       = var.install_materialize_instance ? module.self_signed_cluster_issuer[0].issuer_name : null
+  value       = module.self_signed_cluster_issuer.issuer_name
 }

--- a/test/gcp/fixtures/materialize/variables.tf
+++ b/test/gcp/fixtures/materialize/variables.tf
@@ -144,11 +144,6 @@ variable "operator_namespace" {
 }
 
 # Materialize Instance variables
-variable "install_materialize_instance" {
-  description = "Whether to install the Materialize instance"
-  type        = bool
-}
-
 variable "instance_name" {
   description = "Name of the Materialize instance"
   type        = string

--- a/test/gcp/fixtures/materialize/versions.tf
+++ b/test/gcp/fixtures/materialize/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.8"
 
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.0"
+      version = ">= 6.31, < 7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -12,6 +12,18 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    deepmerge = {
+      source  = "isometry/deepmerge"
+      version = "~> 1.0"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
       version = "~> 2.0"
     }
   }

--- a/test/gcp/staged_deployment_test.go
+++ b/test/gcp/staged_deployment_test.go
@@ -362,7 +362,6 @@ func (suite *StagedDeploymentSuite) setupMaterializeConsolidatedStage(stage, sta
 		"operator_namespace": expectedOperatorNamespace,
 
 		// Materialize Instance Configuration
-		"install_materialize_instance": false,
 		"instance_name":                TestMaterializeInstanceName,
 		"instance_namespace":           expectedInstanceNamespace,
 		"user": map[string]interface{}{
@@ -391,15 +390,6 @@ func (suite *StagedDeploymentSuite) setupMaterializeConsolidatedStage(stage, sta
 
 	// Apply
 	terraform.InitAndApply(t, materializeOptions)
-
-	t.Logf("✅ Phase 1: Materialize operator installed on cluster where disk-enabled: %t", diskEnabled)
-
-	// Phase 2: Update terraform.tfvars.json file for instance deployment
-	variables["install_materialize_instance"] = true
-	helpers.CreateTfvarsFile(t, tfvarsPath, variables)
-
-	// Phase 2: Apply with instance enabled
-	terraform.Apply(t, materializeOptions)
 
 	// Validate all outputs from the consolidated fixture
 	t.Log("🔍 Validating all consolidated fixture outputs...")
@@ -431,7 +421,7 @@ func (suite *StagedDeploymentSuite) setupMaterializeConsolidatedStage(stage, sta
 	t.Log("✅ Validating Materialize Instance Outputs...")
 	suite.NotEmpty(instanceResourceId, "Materialize instance resource ID should not be empty")
 
-	t.Logf("✅ Phase 2: Complete Materialize stack created successfully:")
+	t.Logf("✅ Complete Materialize stack created successfully:")
 	t.Logf("  💾 Disk Enabled: %t", diskEnabled)
 
 	// GKE Cluster Outputs


### PR DESCRIPTION
Switch to the alekc kubectl provider with `kubectl_manifest` instead of the Hashicorp kubernetes provider and `kubernetes_manifest`.

This allows us to run the entire terraform deployment in a single apply.