### PR TITLE
Increase nodepool termination grace period to 300s.

### DIFF
--- a/aws/modules/karpenter-nodepool/main.tf
+++ b/aws/modules/karpenter-nodepool/main.tf
@@ -61,7 +61,7 @@ resource "kubectl_manifest" "nodepool" {
               },
             ],
             "taints" : var.node_taints,
-            "terminationGracePeriod" : "60s",
+            "terminationGracePeriod" : "300s",
           },
         },
       },


### PR DESCRIPTION
Increase nodepool termination grace period to 300s.

Hopefully this will give enough time for the AWS CNI pod to clean up its ENIs before terminating the node.