### PR TITLE
Add OEL image support to Ory Kratos and Hydra modules

### DIFF
--- a/kubernetes/modules/ory-hydra/README.md
+++ b/kubernetes/modules/ory-hydra/README.md
@@ -40,6 +40,9 @@ No modules.
 | <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Whether to create the Kubernetes namespace. Set to false if the namespace already exists. | `bool` | `true` | no |
 | <a name="input_dsn"></a> [dsn](#input\_dsn) | PostgreSQL DSN for Hydra database connection. Example: postgres://user:password@host:5432/hydra?sslmode=require | `string` | n/a | yes |
 | <a name="input_helm_values"></a> [helm\_values](#input\_helm\_values) | Additional values to pass to the Helm chart. These will be deep-merged with the module's default values, with these values taking precedence. | `any` | `{}` | no |
+| <a name="input_image_pull_secrets"></a> [image\_pull\_secrets](#input\_image\_pull\_secrets) | List of Kubernetes secret names for pulling images from private registries. Required for OEL deployments. | `list(string)` | `[]` | no |
+| <a name="input_image_repository"></a> [image\_repository](#input\_image\_repository) | Override the Docker image repository for Hydra. Must include the full registry path as the Ory Helm chart ignores image.registry. Example: europe-docker.pkg.dev/ory-artifacts/ory-enterprise/hydra-oel | `string` | `null` | no |
+| <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Override the Docker image tag for Hydra. If not set, the chart default will be used. | `string` | `null` | no |
 | <a name="input_install_timeout"></a> [install\_timeout](#input\_install\_timeout) | Timeout for installing the Ory Hydra Helm chart, in seconds. | `number` | `600` | no |
 | <a name="input_issuer_url"></a> [issuer\_url](#input\_issuer\_url) | The public URL of the OAuth2 issuer. Used for OIDC discovery. Example: https://auth.example.com/ | `string` | n/a | yes |
 | <a name="input_login_url"></a> [login\_url](#input\_login\_url) | The URL of the login UI. Hydra redirects users here for authentication. Example: https://login.example.com/login | `string` | `null` | no |

--- a/kubernetes/modules/ory-hydra/main.tf
+++ b/kubernetes/modules/ory-hydra/main.tf
@@ -24,6 +24,18 @@ locals {
   secrets_system = var.secrets_system != null ? var.secrets_system : random_password.secrets_system[0].result
   secrets_cookie = var.secrets_cookie != null ? var.secrets_cookie : random_password.secrets_cookie[0].result
 
+  image_config = var.image_registry != null || var.image_repository != null || var.image_tag != null ? {
+    image = merge(
+      var.image_registry != null ? { registry = var.image_registry } : {},
+      var.image_repository != null ? { repository = var.image_repository } : {},
+      var.image_tag != null ? { tag = var.image_tag } : {},
+    )
+  } : {}
+
+  image_pull_secrets_config = length(var.image_pull_secrets) > 0 ? {
+    imagePullSecrets = [for name in var.image_pull_secrets : { name = name }]
+  } : {}
+
   urls_config = merge(
     {
       self = {
@@ -35,7 +47,7 @@ locals {
     var.logout_url != null ? { logout = var.logout_url } : {},
   )
 
-  default_helm_values = {
+  default_helm_values = merge({
     replicaCount = var.replica_count
 
     secret = {
@@ -115,7 +127,7 @@ locals {
         port    = 4445
       }
     }
-  }
+  }, local.image_config, local.image_pull_secrets_config)
 }
 
 resource "helm_release" "hydra" {

--- a/kubernetes/modules/ory-hydra/main.tf
+++ b/kubernetes/modules/ory-hydra/main.tf
@@ -24,9 +24,8 @@ locals {
   secrets_system = var.secrets_system != null ? var.secrets_system : random_password.secrets_system[0].result
   secrets_cookie = var.secrets_cookie != null ? var.secrets_cookie : random_password.secrets_cookie[0].result
 
-  image_config = var.image_registry != null || var.image_repository != null || var.image_tag != null ? {
+  image_config = var.image_repository != null || var.image_tag != null ? {
     image = merge(
-      var.image_registry != null ? { registry = var.image_registry } : {},
       var.image_repository != null ? { repository = var.image_repository } : {},
       var.image_tag != null ? { tag = var.image_tag } : {},
     )

--- a/kubernetes/modules/ory-hydra/variables.tf
+++ b/kubernetes/modules/ory-hydra/variables.tf
@@ -164,14 +164,8 @@ variable "maester_enabled" {
   nullable    = false
 }
 
-variable "image_registry" {
-  description = "Override the Docker image registry for Hydra. Used for OEL (Ory Enterprise License) deployments. Example: europe-docker.pkg.dev"
-  type        = string
-  default     = null
-}
-
 variable "image_repository" {
-  description = "Override the Docker image repository for Hydra. Used for OEL deployments. Example: ory-artifacts/ory-enterprise/hydra-oel"
+  description = "Override the Docker image repository for Hydra. Must include the full registry path as the Ory Helm chart ignores image.registry. Example: europe-docker.pkg.dev/ory-artifacts/ory-enterprise/hydra-oel"
   type        = string
   default     = null
 }

--- a/kubernetes/modules/ory-hydra/variables.tf
+++ b/kubernetes/modules/ory-hydra/variables.tf
@@ -164,6 +164,31 @@ variable "maester_enabled" {
   nullable    = false
 }
 
+variable "image_registry" {
+  description = "Override the Docker image registry for Hydra. Used for OEL (Ory Enterprise License) deployments. Example: europe-docker.pkg.dev"
+  type        = string
+  default     = null
+}
+
+variable "image_repository" {
+  description = "Override the Docker image repository for Hydra. Used for OEL deployments. Example: ory-artifacts/ory-enterprise/hydra-oel"
+  type        = string
+  default     = null
+}
+
+variable "image_tag" {
+  description = "Override the Docker image tag for Hydra. If not set, the chart default will be used."
+  type        = string
+  default     = null
+}
+
+variable "image_pull_secrets" {
+  description = "List of Kubernetes secret names for pulling images from private registries. Required for OEL deployments."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
 variable "helm_values" {
   description = "Additional values to pass to the Helm chart. These will be deep-merged with the module's default values, with these values taking precedence."
   type        = any

--- a/kubernetes/modules/ory-kratos/README.md
+++ b/kubernetes/modules/ory-kratos/README.md
@@ -42,6 +42,9 @@ No modules.
 | <a name="input_dsn"></a> [dsn](#input\_dsn) | PostgreSQL DSN for Kratos database connection. Example: postgres://user:password@host:5432/kratos?sslmode=require | `string` | n/a | yes |
 | <a name="input_helm_values"></a> [helm\_values](#input\_helm\_values) | Additional values to pass to the Helm chart. These will be deep-merged with the module's default values, with these values taking precedence. | `any` | `{}` | no |
 | <a name="input_identity_schemas"></a> [identity\_schemas](#input\_identity\_schemas) | Map of identity schema filenames to their JSON content. Example: { "identity.default.schema.json" = file("schemas/default.json") } | `map(string)` | `{}` | no |
+| <a name="input_image_pull_secrets"></a> [image\_pull\_secrets](#input\_image\_pull\_secrets) | List of Kubernetes secret names for pulling images from private registries. Required for OEL deployments. | `list(string)` | `[]` | no |
+| <a name="input_image_repository"></a> [image\_repository](#input\_image\_repository) | Override the Docker image repository for Kratos. Must include the full registry path as the Ory Helm chart ignores image.registry. Example: europe-docker.pkg.dev/ory-artifacts/ory-enterprise-kratos/kratos-oel | `string` | `null` | no |
+| <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Override the Docker image tag for Kratos. If not set, the chart default will be used. | `string` | `null` | no |
 | <a name="input_install_timeout"></a> [install\_timeout](#input\_install\_timeout) | Timeout for installing the Ory Kratos Helm chart, in seconds. | `number` | `600` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace for Ory Kratos. | `string` | `"ory-kratos"` | no |
 | <a name="input_node_selector"></a> [node\_selector](#input\_node\_selector) | Node selector for Kratos pods. | `map(string)` | `{}` | no |

--- a/kubernetes/modules/ory-kratos/main.tf
+++ b/kubernetes/modules/ory-kratos/main.tf
@@ -35,9 +35,8 @@ locals {
     identitySchemas = var.identity_schemas
   } : {}
 
-  image_config = var.image_registry != null || var.image_repository != null || var.image_tag != null ? {
+  image_config = var.image_repository != null || var.image_tag != null ? {
     image = merge(
-      var.image_registry != null ? { registry = var.image_registry } : {},
       var.image_repository != null ? { repository = var.image_repository } : {},
       var.image_tag != null ? { tag = var.image_tag } : {},
     )

--- a/kubernetes/modules/ory-kratos/main.tf
+++ b/kubernetes/modules/ory-kratos/main.tf
@@ -35,6 +35,18 @@ locals {
     identitySchemas = var.identity_schemas
   } : {}
 
+  image_config = var.image_registry != null || var.image_repository != null || var.image_tag != null ? {
+    image = merge(
+      var.image_registry != null ? { registry = var.image_registry } : {},
+      var.image_repository != null ? { repository = var.image_repository } : {},
+      var.image_tag != null ? { tag = var.image_tag } : {},
+    )
+  } : {}
+
+  image_pull_secrets_config = length(var.image_pull_secrets) > 0 ? {
+    imagePullSecrets = [for name in var.image_pull_secrets : { name = name }]
+  } : {}
+
   smtp_config = var.smtp_connection_uri != null ? {
     courier = {
       smtp = merge(
@@ -45,7 +57,7 @@ locals {
     }
   } : {}
 
-  default_helm_values = {
+  default_helm_values = merge({
     replicaCount = var.replica_count
 
     secret = {
@@ -130,7 +142,7 @@ locals {
         port    = 4434
       }
     }
-  }
+  }, local.image_config, local.image_pull_secrets_config)
 }
 
 resource "helm_release" "kratos" {

--- a/kubernetes/modules/ory-kratos/variables.tf
+++ b/kubernetes/modules/ory-kratos/variables.tf
@@ -172,14 +172,8 @@ variable "smtp_from_name" {
   default     = null
 }
 
-variable "image_registry" {
-  description = "Override the Docker image registry for Kratos. Used for OEL (Ory Enterprise License) deployments. Example: europe-docker.pkg.dev"
-  type        = string
-  default     = null
-}
-
 variable "image_repository" {
-  description = "Override the Docker image repository for Kratos. Used for OEL deployments. Example: ory-artifacts/ory-enterprise-kratos/kratos-oel"
+  description = "Override the Docker image repository for Kratos. Must include the full registry path as the Ory Helm chart ignores image.registry. Example: europe-docker.pkg.dev/ory-artifacts/ory-enterprise-kratos/kratos-oel"
   type        = string
   default     = null
 }

--- a/kubernetes/modules/ory-kratos/variables.tf
+++ b/kubernetes/modules/ory-kratos/variables.tf
@@ -172,6 +172,31 @@ variable "smtp_from_name" {
   default     = null
 }
 
+variable "image_registry" {
+  description = "Override the Docker image registry for Kratos. Used for OEL (Ory Enterprise License) deployments. Example: europe-docker.pkg.dev"
+  type        = string
+  default     = null
+}
+
+variable "image_repository" {
+  description = "Override the Docker image repository for Kratos. Used for OEL deployments. Example: ory-artifacts/ory-enterprise-kratos/kratos-oel"
+  type        = string
+  default     = null
+}
+
+variable "image_tag" {
+  description = "Override the Docker image tag for Kratos. If not set, the chart default will be used."
+  type        = string
+  default     = null
+}
+
+variable "image_pull_secrets" {
+  description = "List of Kubernetes secret names for pulling images from private registries. Required for OEL deployments."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
 variable "helm_values" {
   description = "Additional values to pass to the Helm chart. These will be deep-merged with the module's default values, with these values taking precedence."
   type        = any


### PR DESCRIPTION
Adding those vars to ory-kratos and ory-hydra modules to support Ory Enterprise License deployments with private registry images.