### PR TITLE
Regenerate module README docs via terraform-docs

### DIFF
--- a/aws/modules/eks-node-group/README.md
+++ b/aws/modules/eks-node-group/README.md
@@ -2,13 +2,15 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -18,13 +20,17 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [terraform_data.eni_cleanup](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ami_type"></a> [ami\_type](#input\_ami\_type) | AMI type for the node group. | `string` | `"BOTTLEROCKET_ARM_64"` | no |
+| <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS CLI profile, used for destroy-time ENI cleanup. If empty, the default credential chain is used. | `string` | `""` | no |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region, used for destroy-time ENI cleanup. | `string` | n/a | yes |
 | <a name="input_capacity_type"></a> [capacity\_type](#input\_capacity\_type) | Capacity type for worker nodes (ON\_DEMAND or SPOT). | `string` | `"ON_DEMAND"` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the EKS cluster to attach the node group to. | `string` | n/a | yes |
 | <a name="input_cluster_primary_security_group_id"></a> [cluster\_primary\_security\_group\_id](#input\_cluster\_primary\_security\_group\_id) | The ID of the primary security group for the cluster | `string` | n/a | yes |
@@ -34,6 +40,7 @@ No resources.
 | <a name="input_iam_role_use_name_prefix"></a> [iam\_role\_use\_name\_prefix](#input\_iam\_role\_use\_name\_prefix) | Use name prefix for IAM roles | `bool` | `true` | no |
 | <a name="input_instance_types"></a> [instance\_types](#input\_instance\_types) | Instance types for worker nodes.<br/><br/>Recommended Configuration:<br/>- For other workloads: `r7g`, `r6g` families (ARM-based Graviton, without local disks)<br/>- For materialize instance workloads: `r6gd`, `r7gd` families (ARM-based Graviton, with local NVMe disks)<br/>- Enable disk setup when using instance types with local storage | `list(string)` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the node group. | `map(string)` | `{}` | no |
+| <a name="input_launch_template_name"></a> [launch\_template\_name](#input\_launch\_template\_name) | Explicit name for the launch template. If null, the upstream module generates a name based on the node group. Set this to control the exact launch template name, e.g., to preserve existing launch templates during infrastructure changes. | `string` | `null` | no |
 | <a name="input_max_size"></a> [max\_size](#input\_max\_size) | Maximum number of worker nodes. | `number` | `4` | no |
 | <a name="input_min_size"></a> [min\_size](#input\_min\_size) | Minimum number of worker nodes. | `number` | `1` | no |
 | <a name="input_node_group_name"></a> [node\_group\_name](#input\_node\_group\_name) | Name of the node group. | `string` | n/a | yes |

--- a/aws/modules/nlb/README.md
+++ b/aws/modules/nlb/README.md
@@ -40,6 +40,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Whether to create a dedicated security group for the NLB with ingress rules for Materialize ports. Set to false if security groups are managed externally or not needed. | `bool` | `true` | no |
 | <a name="input_enable_cross_zone_load_balancing"></a> [enable\_cross\_zone\_load\_balancing](#input\_enable\_cross\_zone\_load\_balancing) | Whether to enable cross zone load balancing on the NLB. | `bool` | `true` | no |
 | <a name="input_ingress_cidr_blocks"></a> [ingress\_cidr\_blocks](#input\_ingress\_cidr\_blocks) | List of CIDR blocks to allow ingress to the NLB Security Group. | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
 | <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | The name of the Materialize instance. | `string` | n/a | yes |
@@ -47,6 +48,7 @@
 | <a name="input_mz_resource_id"></a> [mz\_resource\_id](#input\_mz\_resource\_id) | The resourceId from the Materialize CR | `string` | n/a | yes |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix to use for NLB, Target Groups, Listeners, and TargetGroupBindings | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace in which to install TargetGroupBindings | `string` | n/a | yes |
+| <a name="input_nlb_name"></a> [nlb\_name](#input\_nlb\_name) | Explicit name for the NLB. If set, uses this instead of name\_prefix. Use when a specific, predictable NLB name is required. | `string` | `null` | no |
 | <a name="input_node_security_group_id"></a> [node\_security\_group\_id](#input\_node\_security\_group\_id) | ID of the EKS Node Security Group to allow traffic to. Used to add ingress rules from the NLB SG. | `string` | n/a | yes |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs in which to install the NLB. Must be in the VPC. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources | `map(string)` | `{}` | no |

--- a/aws/modules/vpc-cni/README.md
+++ b/aws/modules/vpc-cni/README.md
@@ -37,6 +37,7 @@ No modules.
 | <a name="input_enable_network_policy"></a> [enable\_network\_policy](#input\_enable\_network\_policy) | Enable Kubernetes NetworkPolicy support. Requires VPC CNI v1.14+ and Kubernetes 1.25+. | `bool` | `true` | no |
 | <a name="input_enable_policy_event_logs"></a> [enable\_policy\_event\_logs](#input\_enable\_policy\_event\_logs) | Enable logging of network policy events to node/pod logs | `bool` | `true` | no |
 | <a name="input_enable_prefix_delegation"></a> [enable\_prefix\_delegation](#input\_enable\_prefix\_delegation) | Enable prefix delegation for higher pod density per node | `bool` | `false` | no |
+| <a name="input_kubeconfig_data"></a> [kubeconfig\_data](#input\_kubeconfig\_data) | Contents of the kubeconfig used for kubectl commands during resource adoption. | `string` | n/a | yes |
 | <a name="input_minimum_ip_target"></a> [minimum\_ip\_target](#input\_minimum\_ip\_target) | Minimum number of IP addresses to keep available per node | `number` | `null` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for all resource names | `string` | n/a | yes |
 | <a name="input_oidc_issuer_url"></a> [oidc\_issuer\_url](#input\_oidc\_issuer\_url) | URL of the OIDC issuer for the EKS cluster | `string` | n/a | yes |

--- a/azure/modules/storage/README.md
+++ b/azure/modules/storage/README.md
@@ -35,6 +35,7 @@ No modules.
 | <a name="input_container_access_type"></a> [container\_access\_type](#input\_container\_access\_type) | The Access Level configured for this Container. Valid values are: private, blob, container. | `string` | `"private"` | no |
 | <a name="input_container_name"></a> [container\_name](#input\_container\_name) | The name of the Container which should be created within the Storage Account | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The location where resources will be created | `string` | n/a | yes |
+| <a name="input_network_rules_default_action"></a> [network\_rules\_default\_action](#input\_network\_rules\_default\_action) | The default action for storage account network rules when subnets are configured. Use 'Allow' to permit access from all networks (with subnet rules as additions), or 'Deny' to restrict access to only the configured subnets. | `string` | `"Deny"` | no |
 | <a name="input_oidc_issuer_url"></a> [oidc\_issuer\_url](#input\_oidc\_issuer\_url) | The OIDC issuer URL of the AKS cluster | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix to be used for resource names | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group | `string` | n/a | yes |

--- a/gcp/modules/database/README.md
+++ b/gcp/modules/database/README.md
@@ -45,6 +45,7 @@ No resources.
 | <a name="input_point_in_time_recovery_enabled"></a> [point\_in\_time\_recovery\_enabled](#input\_point\_in\_time\_recovery\_enabled) | Enable point in time recovery | `bool` | `true` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix to be used for resource names | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project where resources will be created | `string` | n/a | yes |
+| <a name="input_random_instance_name"></a> [random\_instance\_name](#input\_random\_instance\_name) | Append a random suffix to the instance name to avoid name collisions after deletion (GCP reserves deleted instance names for ~1 week) | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region where resources will be created | `string` | n/a | yes |
 | <a name="input_tier"></a> [tier](#input\_tier) | The machine tier for the database instance | `string` | n/a | yes |
 | <a name="input_update_timeout"></a> [update\_timeout](#input\_update\_timeout) | Timeout for update operations | `string` | `"45m"` | no |

--- a/gcp/modules/networking/README.md
+++ b/gcp/modules/networking/README.md
@@ -34,6 +34,7 @@
 | <a name="input_log_config_enable"></a> [log\_config\_enable](#input\_log\_config\_enable) | Enable logging for the network | `bool` | `true` | no |
 | <a name="input_log_config_filter"></a> [log\_config\_filter](#input\_log\_config\_filter) | Filter for logging | `string` | `"ERRORS_ONLY"` | no |
 | <a name="input_mtu"></a> [mtu](#input\_mtu) | MTU for the network | `number` | `1460` | no |
+| <a name="input_nat_ips"></a> [nat\_ips](#input\_nat\_ips) | List of self\_links of external IPs for Cloud NAT. When non-empty, NAT uses MANUAL\_ONLY allocation with these static IPs instead of auto-allocated ephemeral IPs. | `list(string)` | `[]` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix to be used for resource names | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project where resources will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region where resources will be created | `string` | n/a | yes |
@@ -46,6 +47,7 @@
 
 | Name | Description |
 |------|-------------|
+| <a name="output_nat_ips"></a> [nat\_ips](#output\_nat\_ips) | The self\_links of external IPs assigned to Cloud NAT (empty when using auto-allocated IPs) |
 | <a name="output_nat_name"></a> [nat\_name](#output\_nat\_name) | The name of the Cloud NAT |
 | <a name="output_nat_region"></a> [nat\_region](#output\_nat\_region) | The region of the Cloud NAT |
 | <a name="output_network_id"></a> [network\_id](#output\_network\_id) | The ID of the VPC network |

--- a/gcp/modules/nodepool/README.md
+++ b/gcp/modules/nodepool/README.md
@@ -35,6 +35,7 @@ No modules.
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the GKE cluster | `string` | n/a | yes |
 | <a name="input_disk_setup_container_resource_config"></a> [disk\_setup\_container\_resource\_config](#input\_disk\_setup\_container\_resource\_config) | Resource configuration for disk setup init container | <pre>object({<br/>    memory_limit   = string<br/>    memory_request = string<br/>    cpu_request    = string<br/>  })</pre> | <pre>{<br/>  "cpu_request": "50m",<br/>  "memory_limit": "128Mi",<br/>  "memory_request": "128Mi"<br/>}</pre> | no |
 | <a name="input_disk_setup_image"></a> [disk\_setup\_image](#input\_disk\_setup\_image) | Docker image for the disk setup script | `string` | `"materialize/ephemeral-storage-setup-image:v0.4.1"` | no |
+| <a name="input_disk_setup_name"></a> [disk\_setup\_name](#input\_disk\_setup\_name) | Name used for disk setup Kubernetes resources (namespace, daemonset, service account, cluster role, cluster role binding) | `string` | `"disk-setup"` | no |
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | The disk size in GB for each node | `number` | `100` | no |
 | <a name="input_enable_private_nodes"></a> [enable\_private\_nodes](#input\_enable\_private\_nodes) | Whether to enable private nodes | `bool` | `true` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the nodes | `map(string)` | `{}` | no |

--- a/kubernetes/modules/coredns/README.md
+++ b/kubernetes/modules/coredns/README.md
@@ -37,6 +37,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cluster_identifier"></a> [cluster\_identifier](#input\_cluster\_identifier) | Stable identifier for the cluster (e.g., cluster endpoint or name). Used to trigger re-provisioning when the cluster changes, without embedding ephemeral credentials in triggers. | `string` | `null` | no |
 | <a name="input_coredns_autoscaler_deployment_to_scale_down"></a> [coredns\_autoscaler\_deployment\_to\_scale\_down](#input\_coredns\_autoscaler\_deployment\_to\_scale\_down) | Name of the CoreDNS autoscaler deployment to scale down | `string` | `"coredns-autoscaler"` | no |
 | <a name="input_coredns_deployment_to_scale_down"></a> [coredns\_deployment\_to\_scale\_down](#input\_coredns\_deployment\_to\_scale\_down) | Name of the CoreDNS deployment to scale down | `string` | `"coredns"` | no |
 | <a name="input_coredns_version"></a> [coredns\_version](#input\_coredns\_version) | CoreDNS image version | `string` | `"1.11.1"` | no |

--- a/kubernetes/modules/materialize-instance/README.md
+++ b/kubernetes/modules/materialize-instance/README.md
@@ -3,14 +3,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | ~> 2.0 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.2.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | ~> 2.0 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 2.2.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10.0 |
 
 ## Modules
@@ -39,6 +39,7 @@ No modules.
 | <a name="input_balancer_memory_limit"></a> [balancer\_memory\_limit](#input\_balancer\_memory\_limit) | Memory limit for balancer | `string` | `"256Mi"` | no |
 | <a name="input_balancer_memory_request"></a> [balancer\_memory\_request](#input\_balancer\_memory\_request) | Memory request for balancer | `string` | `"256Mi"` | no |
 | <a name="input_cpu_request"></a> [cpu\_request](#input\_cpu\_request) | CPU request for environmentd | `string` | `"1"` | no |
+| <a name="input_crd_version"></a> [crd\_version](#input\_crd\_version) | CRD API version to use for the Materialize instance (v1alpha1 or v1alpha2). We recommend v1alpha2, but default to v1alpha1 for backwards compatibility. We will change this default in an upcoming major release. | `string` | `"v1alpha1"` | no |
 | <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Whether to create the Kubernetes namespace. Set to false if the namespace already exists. | `bool` | `true` | no |
 | <a name="input_enable_network_policies"></a> [enable\_network\_policies](#input\_enable\_network\_policies) | Enable default-deny-ingress network policy for the instance namespace. Helm chart creates specific allow policies. | `bool` | `true` | no |
 | <a name="input_environmentd_extra_args"></a> [environmentd\_extra\_args](#input\_environmentd\_extra\_args) | Extra command line arguments for environmentd | `list(string)` | `[]` | no |
@@ -56,7 +57,7 @@ No modules.
 | <a name="input_monitoring_namespace"></a> [monitoring\_namespace](#input\_monitoring\_namespace) | Namespace where monitoring resources (Prometheus) are installed. Used for network policy to allow metrics scraping. | `string` | `"monitoring"` | no |
 | <a name="input_persist_backend_url"></a> [persist\_backend\_url](#input\_persist\_backend\_url) | S3 connection URL for persist backend | `string` | n/a | yes |
 | <a name="input_pod_labels"></a> [pod\_labels](#input\_pod\_labels) | Labels for the materialize instance pod | `map(string)` | `{}` | no |
-| <a name="input_request_rollout"></a> [request\_rollout](#input\_request\_rollout) | UUID to request a rollout | `string` | `"00000000-0000-0000-0000-000000000001"` | no |
+| <a name="input_request_rollout"></a> [request\_rollout](#input\_request\_rollout) | UUID to request a rollout (v1alpha1 only, ignored for v1alpha2) | `string` | `"00000000-0000-0000-0000-000000000001"` | no |
 | <a name="input_rollout_strategy"></a> [rollout\_strategy](#input\_rollout\_strategy) | Strategy to use for rollouts | `string` | `"WaitUntilReady"` | no |
 | <a name="input_service_account_annotations"></a> [service\_account\_annotations](#input\_service\_account\_annotations) | Annotations for the service account associated with the materialize instance. Useful for IAM roles assigned to the service account. | `map(string)` | `{}` | no |
 | <a name="input_system_parameters"></a> [system\_parameters](#input\_system\_parameters) | System parameters to configure for the Materialize instance. These are passed via a ConfigMap. Common parameters include max\_connections, allowed\_cluster\_replica\_sizes, max\_clusters, max\_sources, max\_sinks. Set to null to skip creating the ConfigMap. | `map(string)` | `{}` | no |


### PR DESCRIPTION
Just ran the `./.github/scripts/generate-docs.sh` and noticed some outdated README files.