### PR TITLE
Update rand to 0.9.4 to fix RUSTSEC-2026-0097 advisory

### DIFF
--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -1605,9 +1605,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize-terraform-self-managed/actions/runs/24398567954/job/71263517337