### PR TITLE
Add TLS support to ory-kratos module

### DIFF
--- a/kubernetes/modules/ory-kratos/README.md
+++ b/kubernetes/modules/ory-kratos/README.md
@@ -59,6 +59,7 @@ No modules.
 | <a name="input_smtp_connection_uri"></a> [smtp\_connection\_uri](#input\_smtp\_connection\_uri) | SMTP connection URI for sending emails. Example: smtp://user:password@smtp.example.com:587/ | `string` | `null` | no |
 | <a name="input_smtp_from_address"></a> [smtp\_from\_address](#input\_smtp\_from\_address) | Email address used as the sender for Kratos emails. | `string` | `null` | no |
 | <a name="input_smtp_from_name"></a> [smtp\_from\_name](#input\_smtp\_from\_name) | Name used as the sender for Kratos emails. | `string` | `null` | no |
+| <a name="input_tls_cert_secret_name"></a> [tls\_cert\_secret\_name](#input\_tls\_cert\_secret\_name) | Name of a Kubernetes TLS secret (containing tls.crt and tls.key) to mount into the Kratos container and serve HTTPS from. Typically created by cert-manager. When set, Kratos's public API serves TLS directly. | `string` | `null` | no |
 | <a name="input_tolerations"></a> [tolerations](#input\_tolerations) | Tolerations for Kratos pods. | <pre>list(object({<br/>    key      = string<br/>    value    = optional(string)<br/>    operator = optional(string, "Equal")<br/>    effect   = string<br/>  }))</pre> | `[]` | no |
 
 ## Outputs
@@ -67,7 +68,7 @@ No modules.
 |------|-------------|
 | <a name="output_admin_url"></a> [admin\_url](#output\_admin\_url) | Internal URL for Kratos admin API (privileged: identity CRUD, session management) |
 | <a name="output_namespace"></a> [namespace](#output\_namespace) | Namespace where Ory Kratos is deployed |
-| <a name="output_public_url"></a> [public\_url](#output\_public\_url) | Internal URL for Kratos public API (user-facing: login, registration, session checks) |
+| <a name="output_public_url"></a> [public\_url](#output\_public\_url) | Internal URL for Kratos public API (user-facing: login, registration, session checks). Uses https when tls\_cert\_secret\_name is set. |
 | <a name="output_release_name"></a> [release\_name](#output\_release\_name) | Name of the Ory Kratos Helm release |
 | <a name="output_release_status"></a> [release\_status](#output\_release\_status) | Status of the Ory Kratos Helm release |
 | <a name="output_secrets_cipher"></a> [secrets\_cipher](#output\_secrets\_cipher) | Cipher secret used by Kratos |

--- a/kubernetes/modules/ory-kratos/main.tf
+++ b/kubernetes/modules/ory-kratos/main.tf
@@ -46,6 +46,46 @@ locals {
     imagePullSecrets = [for name in var.image_pull_secrets : { name = name }]
   } : {}
 
+  tls_enabled   = var.tls_cert_secret_name != null
+  tls_mount_dir = "/etc/kratos/tls"
+
+  # Configure TLS on the public listener so Kratos serves HTTPS. Kratos enables
+  # TLS whenever cert/key paths are set — unlike Hydra, there's no `enabled` field.
+  tls_kratos_config = local.tls_enabled ? {
+    kratos = {
+      config = {
+        serve = {
+          public = {
+            tls = {
+              cert = { path = "${local.tls_mount_dir}/tls.crt" }
+              key  = { path = "${local.tls_mount_dir}/tls.key" }
+            }
+          }
+        }
+      }
+    }
+  } : {}
+
+  tls_deployment_config = local.tls_enabled ? {
+    deployment = {
+      extraVolumes = [
+        {
+          name = "tls-cert"
+          secret = {
+            secretName = var.tls_cert_secret_name
+          }
+        },
+      ]
+      extraVolumeMounts = [
+        {
+          name      = "tls-cert"
+          mountPath = local.tls_mount_dir
+          readOnly  = true
+        },
+      ]
+    }
+  } : {}
+
   smtp_config = var.smtp_connection_uri != null ? {
     courier = {
       smtp = merge(
@@ -142,6 +182,12 @@ locals {
       }
     }
   }, local.image_config, local.image_pull_secrets_config)
+
+  # Deep-merge TLS config into hydra.config and deployment blocks.
+  default_helm_values_with_tls = provider::deepmerge::mergo(
+    provider::deepmerge::mergo(local.default_helm_values, local.tls_kratos_config),
+    local.tls_deployment_config,
+  )
 }
 
 resource "helm_release" "kratos" {
@@ -153,7 +199,7 @@ resource "helm_release" "kratos" {
   timeout    = var.install_timeout
 
   values = [
-    yamlencode(provider::deepmerge::mergo(local.default_helm_values, var.helm_values))
+    yamlencode(provider::deepmerge::mergo(local.default_helm_values_with_tls, var.helm_values))
   ]
 
   depends_on = [

--- a/kubernetes/modules/ory-kratos/outputs.tf
+++ b/kubernetes/modules/ory-kratos/outputs.tf
@@ -1,6 +1,6 @@
 output "public_url" {
-  description = "Internal URL for Kratos public API (user-facing: login, registration, session checks)"
-  value       = "http://${var.release_name}-public.${local.namespace}.svc.cluster.local:4433"
+  description = "Internal URL for Kratos public API (user-facing: login, registration, session checks). Uses https when tls_cert_secret_name is set."
+  value       = "${local.tls_enabled ? "https" : "http"}://${var.release_name}-public.${local.namespace}.svc.cluster.local:4433"
 }
 
 output "admin_url" {

--- a/kubernetes/modules/ory-kratos/variables.tf
+++ b/kubernetes/modules/ory-kratos/variables.tf
@@ -191,6 +191,12 @@ variable "image_pull_secrets" {
   nullable    = false
 }
 
+variable "tls_cert_secret_name" {
+  description = "Name of a Kubernetes TLS secret (containing tls.crt and tls.key) to mount into the Kratos container and serve HTTPS from. Typically created by cert-manager. When set, Kratos's public API serves TLS directly."
+  type        = string
+  default     = null
+}
+
 variable "helm_values" {
   description = "Additional values to pass to the Helm chart. These will be deep-merged with the module's default values, with these values taking precedence."
   type        = any


### PR DESCRIPTION
Part of the Ory + Materialize OIDC integration, split from a single WIP branch into focused PRs (#193, #194, #195, #196) for easier review; the cloud specific enterprise example that wires them together will follow once these land.

Adding:
- `tls_cert_secret_name` variable to mount a Kubernetes TLS secret and serve HTTPS from Kratos's public listener.
- Configures Kratos's `serve.public.tls.cert.path` / `key.path` when set. Unlike Hydra, Kratos has no `enabled` field, the presence of the paths activates TLS.
- `public_url` output now returns `https://` when TLS is enabled.
