### PR TITLE
Add ory-selfservice-ui module for Kratos/Hydra login UI

### DIFF
--- a/kubernetes/modules/ory-selfservice-ui/README.md
+++ b/kubernetes/modules/ory-selfservice-ui/README.md
@@ -1,0 +1,66 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [kubernetes_deployment.ui](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment) | resource |
+| [kubernetes_namespace.ui](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_secret.secrets](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_service.ui](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service) | resource |
+| [random_password.cookie_secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_password.csrf_cookie_secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cookie_secret"></a> [cookie\_secret](#input\_cookie\_secret) | Secret for signing cookies. If not set, a random 32-character secret will be generated. | `string` | `null` | no |
+| <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Whether to create the Kubernetes namespace. | `bool` | `false` | no |
+| <a name="input_csrf_cookie_name"></a> [csrf\_cookie\_name](#input\_csrf\_cookie\_name) | Name of the CSRF cookie. Should be prefixed with \_\_HOST- in production. | `string` | `"__HOST-ory-ui-x-csrf-token"` | no |
+| <a name="input_csrf_cookie_secret"></a> [csrf\_cookie\_secret](#input\_csrf\_cookie\_secret) | Secret for CSRF cookie hashing. If not set, a random 32-character secret will be generated. | `string` | `null` | no |
+| <a name="input_disable_secure_csrf_cookies"></a> [disable\_secure\_csrf\_cookies](#input\_disable\_secure\_csrf\_cookies) | Disable secure CSRF cookies. Only use in local development without HTTPS. | `bool` | `false` | no |
+| <a name="input_extra_env"></a> [extra\_env](#input\_extra\_env) | Additional environment variables as a map of name to value. | `map(string)` | `{}` | no |
+| <a name="input_hydra_admin_url"></a> [hydra\_admin\_url](#input\_hydra\_admin\_url) | Internal URL for the Hydra admin API. Example: http://hydra-admin.ory.svc.cluster.local:4445 | `string` | n/a | yes |
+| <a name="input_image_pull_policy"></a> [image\_pull\_policy](#input\_image\_pull\_policy) | Image pull policy. | `string` | `"IfNotPresent"` | no |
+| <a name="input_image_repository"></a> [image\_repository](#input\_image\_repository) | Docker image repository for the selfservice UI. | `string` | `"oryd/kratos-selfservice-ui-node"` | no |
+| <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Docker image tag for the selfservice UI. | `string` | `"v25.4.0"` | no |
+| <a name="input_kratos_admin_url"></a> [kratos\_admin\_url](#input\_kratos\_admin\_url) | Internal URL for the Kratos admin API. Example: http://kratos-admin.ory.svc.cluster.local:4434 | `string` | n/a | yes |
+| <a name="input_kratos_browser_url"></a> [kratos\_browser\_url](#input\_kratos\_browser\_url) | Browser-accessible URL for the Kratos public API. If not set, kratos\_public\_url is used. | `string` | `null` | no |
+| <a name="input_kratos_public_url"></a> [kratos\_public\_url](#input\_kratos\_public\_url) | Internal URL for the Kratos public API. Example: http://kratos-public.ory.svc.cluster.local:4433 | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name for the selfservice UI Kubernetes resources. | `string` | `"ory-selfservice-ui"` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace for the Ory selfservice UI. | `string` | `"ory"` | no |
+| <a name="input_node_selector"></a> [node\_selector](#input\_node\_selector) | Node selector for selfservice UI pods. | `map(string)` | `{}` | no |
+| <a name="input_port"></a> [port](#input\_port) | Port the selfservice UI listens on. | `number` | `3000` | no |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name displayed in the UI. | `string` | `"Materialize"` | no |
+| <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | Number of replicas. | `number` | `2` | no |
+| <a name="input_resources"></a> [resources](#input\_resources) | Resource requests and limits for selfservice UI pods. | <pre>object({<br/>    requests = optional(object({<br/>      cpu    = optional(string, "100m")<br/>      memory = optional(string, "128Mi")<br/>    }))<br/>    limits = optional(object({<br/>      cpu    = optional(string)<br/>      memory = optional(string, "128Mi")<br/>    }))<br/>  })</pre> | <pre>{<br/>  "limits": {},<br/>  "requests": {}<br/>}</pre> | no |
+| <a name="input_tls_cert_secret_name"></a> [tls\_cert\_secret\_name](#input\_tls\_cert\_secret\_name) | Name of a Kubernetes TLS secret (containing tls.crt and tls.key) to mount into the pod and serve HTTPS from. Typically created by cert-manager. When set, the selfservice UI serves HTTPS directly. | `string` | `null` | no |
+| <a name="input_tolerations"></a> [tolerations](#input\_tolerations) | Tolerations for selfservice UI pods. | <pre>list(object({<br/>    key      = string<br/>    value    = optional(string)<br/>    operator = optional(string, "Equal")<br/>    effect   = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_trusted_client_ids"></a> [trusted\_client\_ids](#input\_trusted\_client\_ids) | List of OAuth2 client IDs that are trusted and can skip the consent screen. | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_namespace"></a> [namespace](#output\_namespace) | Namespace where the selfservice UI is deployed. |
+| <a name="output_port"></a> [port](#output\_port) | Port the selfservice UI listens on. |
+| <a name="output_service_name"></a> [service\_name](#output\_service\_name) | Name of the Kubernetes Service for the selfservice UI. |
+| <a name="output_service_url"></a> [service\_url](#output\_service\_url) | Internal URL of the selfservice UI service. Uses https when TLS is enabled. |

--- a/kubernetes/modules/ory-selfservice-ui/main.tf
+++ b/kubernetes/modules/ory-selfservice-ui/main.tf
@@ -1,0 +1,289 @@
+resource "kubernetes_namespace" "ui" {
+  count = var.create_namespace ? 1 : 0
+
+  metadata {
+    name = var.namespace
+  }
+}
+
+resource "random_password" "cookie_secret" {
+  count   = var.cookie_secret == null ? 1 : 0
+  length  = 32
+  special = false
+}
+
+resource "random_password" "csrf_cookie_secret" {
+  count   = var.csrf_cookie_secret == null ? 1 : 0
+  length  = 32
+  special = false
+}
+
+locals {
+  namespace          = var.create_namespace ? kubernetes_namespace.ui[0].metadata[0].name : var.namespace
+  cookie_secret      = var.cookie_secret != null ? var.cookie_secret : random_password.cookie_secret[0].result
+  csrf_cookie_secret = var.csrf_cookie_secret != null ? var.csrf_cookie_secret : random_password.csrf_cookie_secret[0].result
+
+  tls_enabled   = var.tls_cert_secret_name != null
+  tls_mount_dir = "/etc/selfservice-ui/tls"
+  probe_scheme  = local.tls_enabled ? "HTTPS" : "HTTP"
+
+  image = "${var.image_repository}:${var.image_tag}"
+
+  labels = {
+    "app.kubernetes.io/name"       = "kratos-selfservice-ui-node"
+    "app.kubernetes.io/instance"   = var.name
+    "app.kubernetes.io/managed-by" = "terraform"
+    "app.kubernetes.io/part-of"    = "ory"
+  }
+}
+
+resource "kubernetes_secret" "secrets" {
+  metadata {
+    name      = "${var.name}-secrets"
+    namespace = local.namespace
+    labels    = local.labels
+  }
+
+  data = {
+    COOKIE_SECRET      = local.cookie_secret
+    CSRF_COOKIE_SECRET = local.csrf_cookie_secret
+  }
+
+  depends_on = [kubernetes_namespace.ui]
+}
+
+resource "kubernetes_deployment" "ui" {
+  metadata {
+    name      = var.name
+    namespace = local.namespace
+    labels    = local.labels
+  }
+
+  spec {
+    replicas = var.replica_count
+
+    selector {
+      match_labels = {
+        "app.kubernetes.io/name"     = "kratos-selfservice-ui-node"
+        "app.kubernetes.io/instance" = var.name
+      }
+    }
+
+    template {
+      metadata {
+        labels = local.labels
+      }
+
+      spec {
+        dynamic "toleration" {
+          for_each = var.tolerations
+          content {
+            key      = toleration.value.key
+            operator = toleration.value.operator
+            value    = toleration.value.value
+            effect   = toleration.value.effect
+          }
+        }
+
+        node_selector = var.node_selector
+
+        dynamic "volume" {
+          for_each = local.tls_enabled ? [1] : []
+          content {
+            name = "tls-cert"
+            secret {
+              secret_name = var.tls_cert_secret_name
+            }
+          }
+        }
+
+        container {
+          name              = "kratos-selfservice-ui-node"
+          image             = local.image
+          image_pull_policy = var.image_pull_policy
+
+          port {
+            name           = "http"
+            container_port = var.port
+            protocol       = "TCP"
+          }
+
+          dynamic "volume_mount" {
+            for_each = local.tls_enabled ? [1] : []
+            content {
+              name       = "tls-cert"
+              mount_path = local.tls_mount_dir
+              read_only  = true
+            }
+          }
+
+          env {
+            name  = "PORT"
+            value = tostring(var.port)
+          }
+
+          env {
+            name  = "KRATOS_PUBLIC_URL"
+            value = var.kratos_public_url
+          }
+
+          env {
+            name  = "KRATOS_BROWSER_URL"
+            value = var.kratos_browser_url != null ? var.kratos_browser_url : var.kratos_public_url
+          }
+
+          env {
+            name  = "KRATOS_ADMIN_URL"
+            value = var.kratos_admin_url
+          }
+
+          env {
+            name  = "HYDRA_ADMIN_URL"
+            value = var.hydra_admin_url
+          }
+
+          env {
+            name  = "PROJECT_NAME"
+            value = var.project_name
+          }
+
+          env {
+            name  = "CSRF_COOKIE_NAME"
+            value = var.csrf_cookie_name
+          }
+
+          env {
+            name = "COOKIE_SECRET"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.secrets.metadata[0].name
+                key  = "COOKIE_SECRET"
+              }
+            }
+          }
+
+          env {
+            name = "CSRF_COOKIE_SECRET"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.secrets.metadata[0].name
+                key  = "CSRF_COOKIE_SECRET"
+              }
+            }
+          }
+
+          dynamic "env" {
+            for_each = var.disable_secure_csrf_cookies ? [1] : []
+            content {
+              name  = "DANGEROUSLY_DISABLE_SECURE_CSRF_COOKIES"
+              value = "true"
+            }
+          }
+
+          dynamic "env" {
+            for_each = length(var.trusted_client_ids) > 0 ? [1] : []
+            content {
+              name  = "TRUSTED_CLIENT_IDS"
+              value = join(",", var.trusted_client_ids)
+            }
+          }
+
+          dynamic "env" {
+            for_each = local.tls_enabled ? [1] : []
+            content {
+              name  = "TLS_CERT_PATH"
+              value = "${local.tls_mount_dir}/tls.crt"
+            }
+          }
+
+          dynamic "env" {
+            for_each = local.tls_enabled ? [1] : []
+            content {
+              name  = "TLS_KEY_PATH"
+              value = "${local.tls_mount_dir}/tls.key"
+            }
+          }
+
+          # Tell Node.js to trust the CA that issued the mounted cert. Without this,
+          # server-side HTTPS calls from the UI to Kratos/Hydra fail with
+          # UNABLE_TO_VERIFY_LEAF_SIGNATURE when they're behind self-signed certs.
+          dynamic "env" {
+            for_each = local.tls_enabled ? [1] : []
+            content {
+              name  = "NODE_EXTRA_CA_CERTS"
+              value = "${local.tls_mount_dir}/ca.crt"
+            }
+          }
+
+          dynamic "env" {
+            for_each = var.extra_env
+            content {
+              name  = env.key
+              value = env.value
+            }
+          }
+
+          resources {
+            requests = {
+              cpu    = var.resources.requests.cpu
+              memory = var.resources.requests.memory
+            }
+            limits = merge(
+              { memory = var.resources.limits.memory },
+              var.resources.limits.cpu != null ? { cpu = var.resources.limits.cpu } : {}
+            )
+          }
+
+          liveness_probe {
+            http_get {
+              path   = "/health/alive"
+              port   = var.port
+              scheme = local.probe_scheme
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 10
+          }
+
+          readiness_probe {
+            http_get {
+              path   = "/health/ready"
+              port   = var.port
+              scheme = local.probe_scheme
+            }
+            initial_delay_seconds = 3
+            period_seconds        = 5
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    kubernetes_namespace.ui,
+    kubernetes_secret.secrets,
+  ]
+}
+
+resource "kubernetes_service" "ui" {
+  metadata {
+    name      = var.name
+    namespace = local.namespace
+    labels    = local.labels
+  }
+
+  spec {
+    type = "ClusterIP"
+
+    selector = {
+      "app.kubernetes.io/name"     = "kratos-selfservice-ui-node"
+      "app.kubernetes.io/instance" = var.name
+    }
+
+    port {
+      name        = "http"
+      port        = var.port
+      target_port = var.port
+      protocol    = "TCP"
+    }
+  }
+}

--- a/kubernetes/modules/ory-selfservice-ui/outputs.tf
+++ b/kubernetes/modules/ory-selfservice-ui/outputs.tf
@@ -1,0 +1,19 @@
+output "service_name" {
+  description = "Name of the Kubernetes Service for the selfservice UI."
+  value       = kubernetes_service.ui.metadata[0].name
+}
+
+output "service_url" {
+  description = "Internal URL of the selfservice UI service. Uses https when TLS is enabled."
+  value       = "${local.tls_enabled ? "https" : "http"}://${var.name}.${local.namespace}.svc.cluster.local:${var.port}"
+}
+
+output "namespace" {
+  description = "Namespace where the selfservice UI is deployed."
+  value       = local.namespace
+}
+
+output "port" {
+  description = "Port the selfservice UI listens on."
+  value       = var.port
+}

--- a/kubernetes/modules/ory-selfservice-ui/variables.tf
+++ b/kubernetes/modules/ory-selfservice-ui/variables.tf
@@ -1,0 +1,172 @@
+variable "namespace" {
+  description = "Kubernetes namespace for the Ory selfservice UI."
+  type        = string
+  default     = "ory"
+  nullable    = false
+}
+
+variable "create_namespace" {
+  description = "Whether to create the Kubernetes namespace."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "name" {
+  description = "Name for the selfservice UI Kubernetes resources."
+  type        = string
+  default     = "ory-selfservice-ui"
+  nullable    = false
+}
+
+variable "image_repository" {
+  description = "Docker image repository for the selfservice UI."
+  type        = string
+  default     = "oryd/kratos-selfservice-ui-node"
+  nullable    = false
+}
+
+variable "image_tag" {
+  description = "Docker image tag for the selfservice UI."
+  type        = string
+  default     = "v25.4.0"
+  nullable    = false
+}
+
+variable "image_pull_policy" {
+  description = "Image pull policy."
+  type        = string
+  default     = "IfNotPresent"
+  nullable    = false
+}
+
+variable "port" {
+  description = "Port the selfservice UI listens on."
+  type        = number
+  default     = 3000
+  nullable    = false
+}
+
+variable "kratos_public_url" {
+  description = "Internal URL for the Kratos public API. Example: http://kratos-public.ory.svc.cluster.local:4433"
+  type        = string
+  nullable    = false
+}
+
+variable "kratos_admin_url" {
+  description = "Internal URL for the Kratos admin API. Example: http://kratos-admin.ory.svc.cluster.local:4434"
+  type        = string
+  nullable    = false
+}
+
+variable "kratos_browser_url" {
+  description = "Browser-accessible URL for the Kratos public API. If not set, kratos_public_url is used."
+  type        = string
+  default     = null
+}
+
+variable "hydra_admin_url" {
+  description = "Internal URL for the Hydra admin API. Example: http://hydra-admin.ory.svc.cluster.local:4445"
+  type        = string
+  nullable    = false
+}
+
+variable "cookie_secret" {
+  description = "Secret for signing cookies. If not set, a random 32-character secret will be generated."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "csrf_cookie_secret" {
+  description = "Secret for CSRF cookie hashing. If not set, a random 32-character secret will be generated."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "csrf_cookie_name" {
+  description = "Name of the CSRF cookie. Should be prefixed with __HOST- in production."
+  type        = string
+  default     = "__HOST-ory-ui-x-csrf-token"
+  nullable    = false
+}
+
+variable "disable_secure_csrf_cookies" {
+  description = "Disable secure CSRF cookies. Only use in local development without HTTPS."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "tls_cert_secret_name" {
+  description = "Name of a Kubernetes TLS secret (containing tls.crt and tls.key) to mount into the pod and serve HTTPS from. Typically created by cert-manager. When set, the selfservice UI serves HTTPS directly."
+  type        = string
+  default     = null
+}
+
+variable "trusted_client_ids" {
+  description = "List of OAuth2 client IDs that are trusted and can skip the consent screen."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+variable "project_name" {
+  description = "Project name displayed in the UI."
+  type        = string
+  default     = "Materialize"
+  nullable    = false
+}
+
+variable "replica_count" {
+  description = "Number of replicas."
+  type        = number
+  default     = 2
+  nullable    = false
+}
+
+variable "resources" {
+  description = "Resource requests and limits for selfservice UI pods."
+  type = object({
+    requests = optional(object({
+      cpu    = optional(string, "100m")
+      memory = optional(string, "128Mi")
+    }))
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "128Mi")
+    }))
+  })
+  default = {
+    requests = {}
+    limits   = {}
+  }
+  nullable = false
+}
+
+variable "node_selector" {
+  description = "Node selector for selfservice UI pods."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}
+
+variable "tolerations" {
+  description = "Tolerations for selfservice UI pods."
+  type = list(object({
+    key      = string
+    value    = optional(string)
+    operator = optional(string, "Equal")
+    effect   = string
+  }))
+  default  = []
+  nullable = false
+}
+
+variable "extra_env" {
+  description = "Additional environment variables as a map of name to value."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/kubernetes/modules/ory-selfservice-ui/versions.tf
+++ b/kubernetes/modules/ory-selfservice-ui/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.8"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
+  }
+}


### PR DESCRIPTION
Part of the Ory + Materialize OIDC integration, split from a single WIP branch into focused PRs (#193, #194, #195, #196) for easier review; the cloud specific enterprise example that wires them together will follow once these land.

Introducing a new module at `kubernetes/modules/ory-selfservice-ui/` that deploys the `kratos-selfservice-ui-node` reference UI, which serves Kratos's login/registration/recovery flows and Hydra's consent screen.