### PR TITLE
Add extra DNS names to materialize-instance TLS certs

### DIFF
--- a/kubernetes/modules/materialize-instance/README.md
+++ b/kubernetes/modules/materialize-instance/README.md
@@ -38,6 +38,8 @@ No modules.
 | <a name="input_balancer_cpu_request"></a> [balancer\_cpu\_request](#input\_balancer\_cpu\_request) | CPU request for balancer | `string` | `"100m"` | no |
 | <a name="input_balancer_memory_limit"></a> [balancer\_memory\_limit](#input\_balancer\_memory\_limit) | Memory limit for balancer | `string` | `"256Mi"` | no |
 | <a name="input_balancer_memory_request"></a> [balancer\_memory\_request](#input\_balancer\_memory\_request) | Memory request for balancer | `string` | `"256Mi"` | no |
+| <a name="input_balancerd_extra_dns_names"></a> [balancerd\_extra\_dns\_names](#input\_balancerd\_extra\_dns\_names) | Additional DNS names to include in the balancerd TLS certificate. Useful when balancerd is exposed via an external hostname. | `list(string)` | `[]` | no |
+| <a name="input_console_extra_dns_names"></a> [console\_extra\_dns\_names](#input\_console\_extra\_dns\_names) | Additional DNS names to include in the console TLS certificate. Useful when the console is exposed via an external hostname (e.g., materialize.internal.example.com). | `list(string)` | `[]` | no |
 | <a name="input_cpu_request"></a> [cpu\_request](#input\_cpu\_request) | CPU request for environmentd | `string` | `"1"` | no |
 | <a name="input_crd_version"></a> [crd\_version](#input\_crd\_version) | CRD API version to use for the Materialize instance (v1alpha1 or v1alpha2). We recommend v1alpha2, but default to v1alpha1 for backwards compatibility. We will change this default in an upcoming major release. | `string` | `"v1alpha1"` | no |
 | <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Whether to create the Kubernetes namespace. Set to false if the namespace already exists. | `bool` | `true` | no |

--- a/kubernetes/modules/materialize-instance/main.tf
+++ b/kubernetes/modules/materialize-instance/main.tf
@@ -80,15 +80,11 @@ resource "kubectl_manifest" "materialize_instance" {
         }
 
         balancerdExternalCertificateSpec = var.issuer_ref == null ? null : {
-          dnsNames = [
-            "balancerd",
-          ]
+          dnsNames  = concat(["balancerd"], var.balancerd_extra_dns_names)
           issuerRef = var.issuer_ref
         }
         consoleExternalCertificateSpec = var.issuer_ref == null ? null : {
-          dnsNames = [
-            "console",
-          ]
+          dnsNames  = concat(["console"], var.console_extra_dns_names)
           issuerRef = var.issuer_ref
         }
         internalCertificateSpec = var.issuer_ref == null ? null : {

--- a/kubernetes/modules/materialize-instance/variables.tf
+++ b/kubernetes/modules/materialize-instance/variables.tf
@@ -193,6 +193,20 @@ variable "issuer_ref" {
   default = null
 }
 
+variable "console_extra_dns_names" {
+  description = "Additional DNS names to include in the console TLS certificate. Useful when the console is exposed via an external hostname (e.g., materialize.internal.example.com)."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+variable "balancerd_extra_dns_names" {
+  description = "Additional DNS names to include in the balancerd TLS certificate. Useful when balancerd is exposed via an external hostname."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
 variable "system_parameters" {
   description = "System parameters to configure for the Materialize instance. These are passed via a ConfigMap. Common parameters include max_connections, allowed_cluster_replica_sizes, max_clusters, max_sources, max_sinks. Set to null to skip creating the ConfigMap."
   type        = map(string)


### PR DESCRIPTION
Part of the Ory + Materialize OIDC integration, split from a single WIP branch into focused PRs (#193, #194, #195, #196) for easier review; the cloud specific enterprise example that wires them together will follow once these land.

Adding:
- `console_extra_dns_names` and `balancerd_extra_dns_names` variables to the `materialize-instance` module.
- The module previously hardcoded `dnsNames = ["console"]` and `["balancerd"]` on the external cert specs. That's fine for in-cluster access, but not when either service is exposed through an external hostname, the cert's CN mismatches and browsers/clients reject it.
