### PR TITLE
Update rustls-webpki to 0.103.13 to fix RUSTSEC-2026-0104

### DIFF
--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -1727,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
Seen at https://github.com/MaterializeInc/materialize-terraform-self-managed/actions/runs/24774547109/job/72489305055