### PR TITLE
Split cargo-deny advisories into scheduled workflow to unblock merge queue

### DIFF
--- a/.github/workflows/advisories.yml
+++ b/.github/workflows/advisories.yml
@@ -1,0 +1,34 @@
+name: Advisories
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  advisories:
+    name: Cargo Deny Advisories
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-advisories-${{ hashFiles('test/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-advisories-
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny
+
+      - name: Run cargo deny advisories
+        working-directory: test
+        run: cargo deny check advisories

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -132,4 +132,8 @@ jobs:
 
       - name: Run cargo deny
         working-directory: test
-        run: cargo deny check
+        # Advisories are checked by the scheduled advisories.yml workflow so
+        # that new RUSTSEC reports cannot flip a green merge queue red without
+        # any code change in the PR. Bans/licenses/sources are deterministic
+        # against Cargo.lock, so they stay blocking.
+        run: cargo deny check bans licenses sources


### PR DESCRIPTION
New RUSTSEC advisories can drop at any time and flip a green merge queue red without any code change in the PR.

That's especially painful here because the merge queue spins up real infra across AWS, GCP, and Azure and takes over an hour see [here](https://github.com/MaterializeInc/materialize-terraform-self-managed/actions/runs/24774547109/job/72489305055), which failed on a `rustls-webpki` advisory in a transitive dep the PR didn't touch.

Advisories will still be caught within 24h via the scheduled job; bans/licenses/sources stay blocking since those are deterministic against `Cargo.lock`.
