### PR TITLE
Add upstream_oidc_providers variable to ory-kratos module

### DIFF
--- a/kubernetes/modules/ory-kratos/README.md
+++ b/kubernetes/modules/ory-kratos/README.md
@@ -61,6 +61,7 @@ No modules.
 | <a name="input_smtp_from_name"></a> [smtp\_from\_name](#input\_smtp\_from\_name) | Name used as the sender for Kratos emails. | `string` | `null` | no |
 | <a name="input_tls_cert_secret_name"></a> [tls\_cert\_secret\_name](#input\_tls\_cert\_secret\_name) | Name of a Kubernetes TLS secret (containing tls.crt and tls.key) to mount into the Kratos container and serve HTTPS from. Typically created by cert-manager. When set, Kratos's public API serves TLS directly. | `string` | `null` | no |
 | <a name="input_tolerations"></a> [tolerations](#input\_tolerations) | Tolerations for Kratos pods. | <pre>list(object({<br/>    key      = string<br/>    value    = optional(string)<br/>    operator = optional(string, "Equal")<br/>    effect   = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_upstream_oidc_providers"></a> [upstream\_oidc\_providers](#input\_upstream\_oidc\_providers) | Upstream OIDC providers to expose as social sign-in methods on the Kratos selfservice UI. Each entry renders as a 'Sign in with X' button. Leave as [] to keep password-only login. The redirect URI to register at the IdP is <kratos public URL>/self-service/methods/oidc/callback/<id>. | <pre>list(object({<br/>    id            = string<br/>    provider      = optional(string, "generic")<br/>    client_id     = string<br/>    client_secret = string<br/>    issuer_url    = string<br/>    scope         = optional(list(string), ["openid", "email", "profile"])<br/>    label         = optional(string)<br/>  }))</pre> | `[]` | no |
 
 ## Outputs
 

--- a/kubernetes/modules/ory-kratos/main.tf
+++ b/kubernetes/modules/ory-kratos/main.tf
@@ -96,6 +96,52 @@ locals {
     }
   } : {}
 
+  # Standard OIDC claim mapper. Maps the upstream IdP's email claim onto the
+  # Kratos identity's email trait. Encoded as a base64:// data URI so Kratos
+  # can read it inline, no ConfigMap needed.
+  upstream_oidc_mapper_jsonnet = <<-EOT
+    local claims = std.extVar('claims');
+    {
+      identity: {
+        traits: {
+          email: claims.email,
+        },
+      },
+    }
+  EOT
+
+  upstream_oidc_mapper_data_uri = "base64://${base64encode(local.upstream_oidc_mapper_jsonnet)}"
+
+  upstream_oidc_config = length(var.upstream_oidc_providers) > 0 ? {
+    kratos = {
+      config = {
+        selfservice = {
+          methods = {
+            oidc = {
+              enabled = true
+              config = {
+                providers = [
+                  for p in var.upstream_oidc_providers : merge(
+                    {
+                      id            = p.id
+                      provider      = p.provider
+                      client_id     = p.client_id
+                      client_secret = p.client_secret
+                      issuer_url    = p.issuer_url
+                      scope         = p.scope
+                      mapper_url    = local.upstream_oidc_mapper_data_uri
+                    },
+                    p.label != null ? { label = p.label } : {},
+                  )
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  } : {}
+
   default_helm_values = merge({
     replicaCount = var.replica_count
 
@@ -183,10 +229,13 @@ locals {
     }
   }, local.image_config, local.image_pull_secrets_config)
 
-  # Deep-merge TLS config into hydra.config and deployment blocks.
-  default_helm_values_with_tls = provider::deepmerge::mergo(
-    provider::deepmerge::mergo(local.default_helm_values, local.tls_kratos_config),
-    local.tls_deployment_config,
+  # Deep-merge optional features (TLS, upstream OIDC) into the default values.
+  default_helm_values_with_extras = provider::deepmerge::mergo(
+    provider::deepmerge::mergo(
+      provider::deepmerge::mergo(local.default_helm_values, local.tls_kratos_config),
+      local.tls_deployment_config,
+    ),
+    local.upstream_oidc_config,
   )
 }
 
@@ -199,7 +248,7 @@ resource "helm_release" "kratos" {
   timeout    = var.install_timeout
 
   values = [
-    yamlencode(provider::deepmerge::mergo(local.default_helm_values_with_tls, var.helm_values))
+    yamlencode(provider::deepmerge::mergo(local.default_helm_values_with_extras, var.helm_values))
   ]
 
   depends_on = [

--- a/kubernetes/modules/ory-kratos/variables.tf
+++ b/kubernetes/modules/ory-kratos/variables.tf
@@ -197,6 +197,22 @@ variable "tls_cert_secret_name" {
   default     = null
 }
 
+variable "upstream_oidc_providers" {
+  description = "Upstream OIDC providers to expose as social sign-in methods on the Kratos selfservice UI. Each entry renders as a 'Sign in with X' button. Leave as [] to keep password-only login. The redirect URI to register at the IdP is <kratos public URL>/self-service/methods/oidc/callback/<id>."
+  type = list(object({
+    id            = string
+    provider      = optional(string, "generic")
+    client_id     = string
+    client_secret = string
+    issuer_url    = string
+    scope         = optional(list(string), ["openid", "email", "profile"])
+    label         = optional(string)
+  }))
+  default   = []
+  nullable  = false
+  sensitive = true
+}
+
 variable "helm_values" {
   description = "Additional values to pass to the Helm chart. These will be deep-merged with the module's default values, with these values taking precedence."
   type        = any


### PR DESCRIPTION
Adding a new `upstream_oidc_providers` variable to the ory-kratos module that lets consumers wire one or more upstream OIDC IdPs (Okta, Microsoft Entra, Auth0, Google Workspace, anything OIDC-compliant) as social sign-in methods on Kratos. 
