### PR TITLE
Add Let's Encrypt ClusterIssuer module (Cloudflare DNS-01)

### DIFF
--- a/kubernetes/modules/letsencrypt-cluster-issuer/README.md
+++ b/kubernetes/modules/letsencrypt-cluster-issuer/README.md
@@ -10,8 +10,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | 2.2.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 3.1.0 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | ~> 2.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10.0 |
 
 ## Modules
 

--- a/kubernetes/modules/letsencrypt-cluster-issuer/README.md
+++ b/kubernetes/modules/letsencrypt-cluster-issuer/README.md
@@ -1,0 +1,45 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | ~> 2.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | 2.2.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 3.1.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [kubectl_manifest.cluster_issuer](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
+| [kubernetes_secret_v1.cloudflare_api_token](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_acme_environment"></a> [acme\_environment](#input\_acme\_environment) | Let's Encrypt environment. Use 'staging' while iterating to avoid the production rate limits (50 certs/week per registered domain). Staging certs are signed by an untrusted CA so browsers will warn. Switch to 'production' once the integration is stable. | `string` | `"staging"` | no |
+| <a name="input_cloudflare_api_token"></a> [cloudflare\_api\_token](#input\_cloudflare\_api\_token) | Cloudflare API token with Zone:Read and DNS:Edit permission, scoped to the zone(s) listed in dns\_zones. Required when dns\_provider is 'cloudflare'. Create one at https://dash.cloudflare.com/profile/api-tokens. | `string` | `null` | no |
+| <a name="input_dns_provider"></a> [dns\_provider](#input\_dns\_provider) | DNS provider used to satisfy ACME dns-01 challenges. Only 'cloudflare' is supported today; other providers can be added by extending this module. | `string` | `"cloudflare"` | no |
+| <a name="input_dns_zones"></a> [dns\_zones](#input\_dns\_zones) | DNS zones (apex domains) the issuer is allowed to solve challenges for. Used as the dnsZones selector on the solver so the ClusterIssuer only attempts challenges for hostnames inside these zones. Example: ["bobby.sh"]. | `list(string)` | n/a | yes |
+| <a name="input_email"></a> [email](#input\_email) | Contact email used for Let's Encrypt account registration. Let's Encrypt sends expiry warnings and account notifications here. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the ClusterIssuer to create. Used as a prefix for the ACME account key Secret and the DNS provider credential Secret. | `string` | `"letsencrypt"` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace where DNS provider credential Secrets are created. Should be the cert-manager namespace so that cert-manager can read the Secrets when solving challenges. | `string` | `"cert-manager"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_issuer_kind"></a> [issuer\_kind](#output\_issuer\_kind) | Kind of the issuer (always ClusterIssuer). |
+| <a name="output_issuer_name"></a> [issuer\_name](#output\_issuer\_name) | Name of the ClusterIssuer that was created. |
+| <a name="output_issuer_ref"></a> [issuer\_ref](#output\_issuer\_ref) | Reference object suitable for passing to modules that accept a cert-manager issuer reference. |

--- a/kubernetes/modules/letsencrypt-cluster-issuer/main.tf
+++ b/kubernetes/modules/letsencrypt-cluster-issuer/main.tf
@@ -1,0 +1,75 @@
+locals {
+  acme_servers = {
+    staging    = "https://acme-staging-v02.api.letsencrypt.org/directory"
+    production = "https://acme-v02.api.letsencrypt.org/directory"
+  }
+
+  acme_server = local.acme_servers[var.acme_environment]
+
+  cloudflare_token_secret_name = "${var.name}-cloudflare-api-token"
+  account_key_secret_name      = "${var.name}-account-key"
+
+  dns01_solver = var.dns_provider == "cloudflare" ? {
+    dns01 = {
+      cloudflare = {
+        apiTokenSecretRef = {
+          name = local.cloudflare_token_secret_name
+          key  = "api-token"
+        }
+      }
+    }
+  } : null
+}
+
+resource "kubernetes_secret_v1" "cloudflare_api_token" {
+  count = var.dns_provider == "cloudflare" ? 1 : 0
+
+  metadata {
+    name      = local.cloudflare_token_secret_name
+    namespace = var.namespace
+  }
+
+  data = {
+    "api-token" = var.cloudflare_api_token
+  }
+
+  type = "Opaque"
+
+  lifecycle {
+    precondition {
+      condition     = var.cloudflare_api_token != null
+      error_message = "cloudflare_api_token must be set when dns_provider = 'cloudflare'."
+    }
+  }
+}
+
+resource "kubectl_manifest" "cluster_issuer" {
+  yaml_body = jsonencode({
+    apiVersion = "cert-manager.io/v1"
+    kind       = "ClusterIssuer"
+    metadata = {
+      name = var.name
+    }
+    spec = {
+      acme = {
+        email  = var.email
+        server = local.acme_server
+        privateKeySecretRef = {
+          name = local.account_key_secret_name
+        }
+        solvers = [
+          {
+            selector = {
+              dnsZones = var.dns_zones
+            }
+            dns01 = local.dns01_solver.dns01
+          },
+        ]
+      }
+    }
+  })
+
+  depends_on = [
+    kubernetes_secret_v1.cloudflare_api_token,
+  ]
+}

--- a/kubernetes/modules/letsencrypt-cluster-issuer/outputs.tf
+++ b/kubernetes/modules/letsencrypt-cluster-issuer/outputs.tf
@@ -1,0 +1,17 @@
+output "issuer_name" {
+  description = "Name of the ClusterIssuer that was created."
+  value       = kubectl_manifest.cluster_issuer.name
+}
+
+output "issuer_kind" {
+  description = "Kind of the issuer (always ClusterIssuer)."
+  value       = "ClusterIssuer"
+}
+
+output "issuer_ref" {
+  description = "Reference object suitable for passing to modules that accept a cert-manager issuer reference."
+  value = {
+    name = kubectl_manifest.cluster_issuer.name
+    kind = "ClusterIssuer"
+  }
+}

--- a/kubernetes/modules/letsencrypt-cluster-issuer/variables.tf
+++ b/kubernetes/modules/letsencrypt-cluster-issuer/variables.tf
@@ -1,0 +1,61 @@
+variable "name" {
+  description = "Name of the ClusterIssuer to create. Used as a prefix for the ACME account key Secret and the DNS provider credential Secret."
+  type        = string
+  default     = "letsencrypt"
+  nullable    = false
+}
+
+variable "namespace" {
+  description = "Namespace where DNS provider credential Secrets are created. Should be the cert-manager namespace so that cert-manager can read the Secrets when solving challenges."
+  type        = string
+  default     = "cert-manager"
+  nullable    = false
+}
+
+variable "email" {
+  description = "Contact email used for Let's Encrypt account registration. Let's Encrypt sends expiry warnings and account notifications here."
+  type        = string
+  nullable    = false
+}
+
+variable "acme_environment" {
+  description = "Let's Encrypt environment. Use 'staging' while iterating to avoid the production rate limits (50 certs/week per registered domain). Staging certs are signed by an untrusted CA so browsers will warn. Switch to 'production' once the integration is stable."
+  type        = string
+  default     = "staging"
+  nullable    = false
+
+  validation {
+    condition     = contains(["staging", "production"], var.acme_environment)
+    error_message = "acme_environment must be 'staging' or 'production'."
+  }
+}
+
+variable "dns_provider" {
+  description = "DNS provider used to satisfy ACME dns-01 challenges. Only 'cloudflare' is supported today; other providers can be added by extending this module."
+  type        = string
+  default     = "cloudflare"
+  nullable    = false
+
+  validation {
+    condition     = contains(["cloudflare"], var.dns_provider)
+    error_message = "dns_provider must be 'cloudflare'."
+  }
+}
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token with Zone:Read and DNS:Edit permission, scoped to the zone(s) listed in dns_zones. Required when dns_provider is 'cloudflare'. Create one at https://dash.cloudflare.com/profile/api-tokens."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "dns_zones" {
+  description = "DNS zones (apex domains) the issuer is allowed to solve challenges for. Used as the dnsZones selector on the solver so the ClusterIssuer only attempts challenges for hostnames inside these zones. Example: [\"bobby.sh\"]."
+  type        = list(string)
+  nullable    = false
+
+  validation {
+    condition     = length(var.dns_zones) > 0
+    error_message = "dns_zones must contain at least one zone."
+  }
+}

--- a/kubernetes/modules/letsencrypt-cluster-issuer/versions.tf
+++ b/kubernetes/modules/letsencrypt-cluster-issuer/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10.0"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "~> 2.0"
+    }
+  }
+}


### PR DESCRIPTION
Adding the `letsencrypt-cluster-issuer` module so the per-cloud Ory enterprise examples can opt into a real ACME issuer (Cloudflare DNS-01 to start, more providers can plug into the `dns_provider` enum later).