### PR TITLE
Add internal_issuer_ref to materialize-instance module

### DIFF
--- a/kubernetes/modules/materialize-instance/README.md
+++ b/kubernetes/modules/materialize-instance/README.md
@@ -10,8 +10,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 2.2.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10.0 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | 2.2.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 3.1.0 |
 
 ## Modules
 
@@ -51,7 +51,8 @@ No modules.
 | <a name="input_force_rollout"></a> [force\_rollout](#input\_force\_rollout) | UUID to force a rollout | `string` | `"00000000-0000-0000-0000-000000000001"` | no |
 | <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | Name of the Materialize instance | `string` | n/a | yes |
 | <a name="input_instance_namespace"></a> [instance\_namespace](#input\_instance\_namespace) | Kubernetes namespace for the instance. | `string` | n/a | yes |
-| <a name="input_issuer_ref"></a> [issuer\_ref](#input\_issuer\_ref) | Reference to a cert-manager Issuer or ClusterIssuer. | <pre>object({<br/>    name = string<br/>    kind = string<br/>  })</pre> | `null` | no |
+| <a name="input_internal_issuer_ref"></a> [internal\_issuer\_ref](#input\_internal\_issuer\_ref) | Optional override for the issuer used to sign cluster-internal mTLS certs (those with *.cluster.local SANs). Required when var.issuer\_ref points at a public ACME issuer such as Let's Encrypt, since public CAs cannot sign cluster.local. When this is set, the short cluster service names ('balancerd', 'console') are also stripped from the external cert SANs because public ACME issuers reject single-label domains. When null, var.issuer\_ref is used for both internal and external certs. | <pre>object({<br/>    name = string<br/>    kind = string<br/>  })</pre> | `null` | no |
+| <a name="input_issuer_ref"></a> [issuer\_ref](#input\_issuer\_ref) | Default cert-manager (Cluster)Issuer used for the instance's TLS certificates. Used for both the external (browser-facing) certs and the internal mTLS certs unless overridden by var.internal\_issuer\_ref. | <pre>object({<br/>    name = string<br/>    kind = string<br/>  })</pre> | `null` | no |
 | <a name="input_license_key"></a> [license\_key](#input\_license\_key) | Materialize license key | `string` | `null` | no |
 | <a name="input_memory_limit"></a> [memory\_limit](#input\_memory\_limit) | Memory limit for environmentd | `string` | `"4Gi"` | no |
 | <a name="input_memory_request"></a> [memory\_request](#input\_memory\_request) | Memory request for environmentd | `string` | `"4095Mi"` | no |

--- a/kubernetes/modules/materialize-instance/README.md
+++ b/kubernetes/modules/materialize-instance/README.md
@@ -10,8 +10,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | 2.2.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 3.1.0 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 2.2.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10.0 |
 
 ## Modules
 

--- a/kubernetes/modules/materialize-instance/main.tf
+++ b/kubernetes/modules/materialize-instance/main.tf
@@ -79,16 +79,24 @@ resource "kubectl_manifest" "materialize_instance" {
           }
         }
 
+        # When var.internal_issuer_ref is set, var.issuer_ref is assumed to be a
+        # public ACME issuer (Let's Encrypt) that cannot sign single-label cluster
+        # service names. In that case, strip "balancerd" / "console" from the
+        # external cert SANs and rely on var.{balancerd,console}_extra_dns_names
+        # for the routable hostnames.
         balancerdExternalCertificateSpec = var.issuer_ref == null ? null : {
-          dnsNames  = concat(["balancerd"], var.balancerd_extra_dns_names)
+          dnsNames  = var.internal_issuer_ref != null ? var.balancerd_extra_dns_names : concat(["balancerd"], var.balancerd_extra_dns_names)
           issuerRef = var.issuer_ref
         }
         consoleExternalCertificateSpec = var.issuer_ref == null ? null : {
-          dnsNames  = concat(["console"], var.console_extra_dns_names)
+          dnsNames  = var.internal_issuer_ref != null ? var.console_extra_dns_names : concat(["console"], var.console_extra_dns_names)
           issuerRef = var.issuer_ref
         }
+        # Internal certs use cluster.local SANs which public ACME issuers reject,
+        # so a separate internal_issuer_ref can be passed (typically a self-signed
+        # cluster issuer). Falls back to issuer_ref when not set.
         internalCertificateSpec = var.issuer_ref == null ? null : {
-          issuerRef = var.issuer_ref
+          issuerRef = var.internal_issuer_ref != null ? var.internal_issuer_ref : var.issuer_ref
         }
       },
       # requestRollout only applies to v1alpha1

--- a/kubernetes/modules/materialize-instance/variables.tf
+++ b/kubernetes/modules/materialize-instance/variables.tf
@@ -185,7 +185,16 @@ variable "pod_labels" {
 
 
 variable "issuer_ref" {
-  description = "Reference to a cert-manager Issuer or ClusterIssuer."
+  description = "Default cert-manager (Cluster)Issuer used for the instance's TLS certificates. Used for both the external (browser-facing) certs and the internal mTLS certs unless overridden by var.internal_issuer_ref."
+  type = object({
+    name = string
+    kind = string
+  })
+  default = null
+}
+
+variable "internal_issuer_ref" {
+  description = "Optional override for the issuer used to sign cluster-internal mTLS certs (those with *.cluster.local SANs). Required when var.issuer_ref points at a public ACME issuer such as Let's Encrypt, since public CAs cannot sign cluster.local. When this is set, the short cluster service names ('balancerd', 'console') are also stripped from the external cert SANs because public ACME issuers reject single-label domains. When null, var.issuer_ref is used for both internal and external certs."
   type = object({
     name = string
     kind = string


### PR DESCRIPTION
Adding an `internal_issuer_ref` variable to the `materialize-instance` module so a public ACME issuer (Let's Encrypt) can be used for the browser-facing balancerd/console certs while a private CA continues to sign the internal mTLS cert (which has `*.cluster.local` SANs that public CAs reject); when set, the short cluster service names (`balancerd`, `console`) are also stripped from the external cert SANs since public CAs reject single-label domains. Prereq for the per-cloud enterprise example PRs (#167, #168, #169) to actually deliver working Let's Encrypt end-to-end.