### PR TITLE
coredns: make scale-up destroy provisioners best-effort

### DIFF
--- a/kubernetes/modules/coredns/main.tf
+++ b/kubernetes/modules/coredns/main.tf
@@ -319,7 +319,11 @@ resource "terraform_data" "scale_down_kube_dns" {
   depends_on = [terraform_data.scale_down_kube_dns_autoscaler]
 }
 
-# Scale up the default CoreDNS during cleanup
+# Scale up the default CoreDNS during cleanup.
+# on_failure = continue: the scale-up is best-effort. If the cluster is also
+# being destroyed or the kubeconfig token has expired, failing here should not
+# block the operation. An operator removing only the CoreDNS module (without
+# destroying the cluster) should verify that kube-dns is running afterward.
 resource "terraform_data" "scale_up_kube_dns_autoscaler" {
   count = var.disable_default_coredns_autoscaler ? 1 : 0
   input = {
@@ -331,7 +335,7 @@ resource "terraform_data" "scale_up_kube_dns_autoscaler" {
   provisioner "local-exec" {
     interpreter = ["/usr/bin/env", "bash", "-c"]
     when        = destroy
-    on_failure  = fail
+    on_failure  = continue
     environment = self.input
     command     = <<-EOT
       set -euo pipefail
@@ -345,7 +349,8 @@ resource "terraform_data" "scale_up_kube_dns_autoscaler" {
           echo "Deployment $${DEPLOYMENT_NAME} not found, skipping"
           exit 0
         fi
-        echo "Error scaling up $${DEPLOYMENT_NAME} deployment: $output"
+        echo "WARNING: Failed to scale up $${DEPLOYMENT_NAME}: $output"
+        echo "If the cluster still exists, manually run: kubectl scale deployment $${DEPLOYMENT_NAME} -n $${NAMESPACE} --replicas=1"
         exit 1
       }
       echo "Successfully scaled up $${DEPLOYMENT_NAME} to 1 replica"
@@ -366,7 +371,7 @@ resource "terraform_data" "scale_up_kube_dns" {
   provisioner "local-exec" {
     interpreter = ["/usr/bin/env", "bash", "-c"]
     when        = destroy
-    on_failure  = fail
+    on_failure  = continue
     environment = self.input
     command     = <<-EOT
       set -euo pipefail
@@ -380,7 +385,8 @@ resource "terraform_data" "scale_up_kube_dns" {
           echo "Deployment $${DEPLOYMENT_NAME} not found, skipping"
           exit 0
         fi
-        echo "Error scaling up kube-dns deployment: $output"
+        echo "WARNING: Failed to scale up $${DEPLOYMENT_NAME}: $output"
+        echo "If the cluster still exists, manually run: kubectl scale deployment $${DEPLOYMENT_NAME} -n $${NAMESPACE} --replicas=2"
         exit 1
       }
       echo "Successfully scaled up $${DEPLOYMENT_NAME} to 2 replicas"


### PR DESCRIPTION
Switches the two coredns scale-up destroy provisioners from `on_failure = fail` to `continue` (with a WARNING that prints the manual `kubectl scale` command) so a cluster-wide teardown or rotated kubeconfig token does not block destroy, the leftover delta from #165 after #171 landed the token-churn fix.