### PR TITLE
Re-enable test-gcp as a required merge queue check

### DIFF
--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -26,7 +26,7 @@ jobs:
     needs:
       - lint
       - test-aws
-      #- test-gcp
+      - test-gcp
       - test-azure
     steps:
       - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3.0.3


### PR DESCRIPTION
Re-enabling the `test-gcp` in the merge queue's `ci-success` required checks. It was temporarily commented out while the GCP CloudSQL / GKE firewall issues were being worked through, those are resolved on main now (STABLE GKE channel pin), so GCP should pass again.

This is split out from #208, which stays open as a tracking PR for the separate AWS operator-egress NetworkPolicy issue (`aws-network-policy-agent` not honoring pod_selector-based egress allows).