### PR TITLE
Drop preflight storage-class data source from grafana and prometheus modules

### DIFF
--- a/kubernetes/modules/grafana/README.md
+++ b/kubernetes/modules/grafana/README.md
@@ -27,7 +27,6 @@ No modules.
 | [kubernetes_config_map.dashboards](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_namespace.grafana](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [random_password.grafana_admin](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [kubernetes_storage_class.grafana](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/storage_class) | data source |
 
 ## Inputs
 

--- a/kubernetes/modules/grafana/main.tf
+++ b/kubernetes/modules/grafana/main.tf
@@ -9,14 +9,6 @@ resource "kubernetes_namespace" "grafana" {
   }
 }
 
-# ensure storage class exists is passed.
-data "kubernetes_storage_class" "grafana" {
-  count = var.storage_class != null ? 1 : 0
-  metadata {
-    name = var.storage_class
-  }
-}
-
 locals {
   # Dashboard URLs from Materialize repository
   # Source: https://github.com/MaterializeInc/materialize/tree/self-managed-docs/v25.2/doc/user/data/monitoring/grafana_dashboards
@@ -132,6 +124,5 @@ resource "helm_release" "grafana" {
 
   depends_on = [
     kubernetes_config_map.dashboards,
-    data.kubernetes_storage_class.grafana,
   ]
 }

--- a/kubernetes/modules/prometheus/README.md
+++ b/kubernetes/modules/prometheus/README.md
@@ -23,7 +23,6 @@ No modules.
 |------|------|
 | [helm_release.prometheus](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_namespace.prometheus](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
-| [kubernetes_storage_class.prometheus](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/storage_class) | data source |
 
 ## Inputs
 

--- a/kubernetes/modules/prometheus/main.tf
+++ b/kubernetes/modules/prometheus/main.tf
@@ -1,13 +1,6 @@
 # Prometheus module for Materialize observability
 # Uses prometheus-community/prometheus Helm chart with Materialize scrape configs
 
-# Verify the storage class exists before deploying Prometheus
-data "kubernetes_storage_class" "prometheus" {
-  metadata {
-    name = var.storage_class
-  }
-}
-
 resource "kubernetes_namespace" "prometheus" {
   count = var.create_namespace ? 1 : 0
 
@@ -90,6 +83,5 @@ resource "helm_release" "prometheus" {
 
   depends_on = [
     kubernetes_namespace.prometheus,
-    data.kubernetes_storage_class.prometheus,
   ]
 }


### PR DESCRIPTION
Removing the `data "kubernetes_storage_class"` preflight in both the `grafana` and `prometheus` modules.

Terraform reads data sources with known inputs at **plan time**. When these modules are used on a **fresh apply**, the AKS / EKS / GKE cluster doesn't exist yet, the kubernetes provider falls back to `localhost`, and the plan errors with `Get "http://localhost/apis/storage.k8s.io/v1/storageclasses/managed-csi": connection refused`. This blocks every from-scratch apply that enables observability.
