### PR TITLE
Drop external cert spec when SANs would be empty under internal_issuer_ref

### DIFF
--- a/kubernetes/modules/materialize-instance/main.tf
+++ b/kubernetes/modules/materialize-instance/main.tf
@@ -86,14 +86,14 @@ resource "kubectl_manifest" "materialize_instance" {
         balancerdExternalCertificateSpec = (
           var.issuer_ref == null ||
           (var.internal_issuer_ref != null && length(var.balancerd_extra_dns_names) == 0)
-        ) ? null : {
+          ) ? null : {
           dnsNames  = var.internal_issuer_ref != null ? var.balancerd_extra_dns_names : concat(["balancerd"], var.balancerd_extra_dns_names)
           issuerRef = var.issuer_ref
         }
         consoleExternalCertificateSpec = (
           var.issuer_ref == null ||
           (var.internal_issuer_ref != null && length(var.console_extra_dns_names) == 0)
-        ) ? null : {
+          ) ? null : {
           dnsNames  = var.internal_issuer_ref != null ? var.console_extra_dns_names : concat(["console"], var.console_extra_dns_names)
           issuerRef = var.issuer_ref
         }

--- a/kubernetes/modules/materialize-instance/main.tf
+++ b/kubernetes/modules/materialize-instance/main.tf
@@ -79,16 +79,21 @@ resource "kubectl_manifest" "materialize_instance" {
           }
         }
 
-        # When var.internal_issuer_ref is set, var.issuer_ref is assumed to be a
-        # public ACME issuer (Let's Encrypt) that cannot sign single-label cluster
-        # service names. In that case, strip "balancerd" / "console" from the
-        # external cert SANs and rely on var.{balancerd,console}_extra_dns_names
-        # for the routable hostnames.
-        balancerdExternalCertificateSpec = var.issuer_ref == null ? null : {
+        # internal_issuer_ref split: public ACME issuers can't sign single-label
+        # cluster service names, so strip "balancerd"/"console" from the SAN list
+        # and rely on the extras. Drop the spec when there are no extras, since
+        # cert-manager rejects Certificates with no SANs.
+        balancerdExternalCertificateSpec = (
+          var.issuer_ref == null ||
+          (var.internal_issuer_ref != null && length(var.balancerd_extra_dns_names) == 0)
+        ) ? null : {
           dnsNames  = var.internal_issuer_ref != null ? var.balancerd_extra_dns_names : concat(["balancerd"], var.balancerd_extra_dns_names)
           issuerRef = var.issuer_ref
         }
-        consoleExternalCertificateSpec = var.issuer_ref == null ? null : {
+        consoleExternalCertificateSpec = (
+          var.issuer_ref == null ||
+          (var.internal_issuer_ref != null && length(var.console_extra_dns_names) == 0)
+        ) ? null : {
           dnsNames  = var.internal_issuer_ref != null ? var.console_extra_dns_names : concat(["console"], var.console_extra_dns_names)
           issuerRef = var.issuer_ref
         }


### PR DESCRIPTION
When `internal_issuer_ref` is set (the Let's Encrypt + self-signed internal split path introduced in #201), the module strips "balancerd" / "console" from the external cert SANs and relies on `balancerd_extra_dns_names` / `console_extra_dns_names` for the routable hostnames. If the consumer leaves those extras empty (the documented "balancerd is intentionally omitted" path used by all three enterprise examples), the resulting `dnsNames` list is empty and cert-manager rejects the Certificate:

```
admission webhook "webhook.cert-manager.io" denied the request: spec: Invalid value: "":
at least one of commonName, dnsNames, uriSANs, ipAddresses, emailSANs or otherNames must be set
```

The Balancer / Materialize CR then never reconciles past cert creation, so balancerd and console never come up.

Fix: when `internal_issuer_ref` is set and the corresponding `extra_dns_names` list is empty, drop the external cert spec entirely (set it to `null`). That matches the original intent of "no external cert for this component" and keeps cert-manager happy.

