### PR TITLE
Make ory-stack work on first apply

### DIFF
--- a/kubernetes/modules/ory-stack/README.md
+++ b/kubernetes/modules/ory-stack/README.md
@@ -83,7 +83,7 @@
 | <a name="output_kratos_external_url"></a> [kratos\_external\_url](#output\_kratos\_external\_url) | External (browser-facing) URL for Kratos public API. |
 | <a name="output_kratos_namespace"></a> [kratos\_namespace](#output\_kratos\_namespace) | Namespace of the Kratos deployment (same as namespace; kept for parity with submodule outputs). |
 | <a name="output_namespace"></a> [namespace](#output\_namespace) | Namespace where Ory is deployed. |
-| <a name="output_oauth2_client_id"></a> [oauth2\_client\_id](#output\_oauth2\_client\_id) | Hydra-Maester-generated OAuth2 client ID for Materialize. Null when materialize\_namespace is not set. |
+| <a name="output_oauth2_client_id"></a> [oauth2\_client\_id](#output\_oauth2\_client\_id) | Hydra-Maester-generated OAuth2 client ID for Materialize. Null when materialize\_namespace is not set, or when the secret has not yet been populated by Hydra Maester (which can happen on a refresh that runs before Maester reconciles). |
 | <a name="output_oauth2_client_secret_name"></a> [oauth2\_client\_secret\_name](#output\_oauth2\_client\_secret\_name) | Name of the Secret that holds the Hydra-Maester-generated OAuth2 client credentials. Null when materialize\_namespace is not set. |
 | <a name="output_oauth2_client_secret_namespace"></a> [oauth2\_client\_secret\_namespace](#output\_oauth2\_client\_secret\_namespace) | Namespace of the OAuth2 client credentials Secret. Null when materialize\_namespace is not set. |
 | <a name="output_oel_registry_secret_name"></a> [oel\_registry\_secret\_name](#output\_oel\_registry\_secret\_name) | Name of the dockerconfigjson Secret holding OEL registry credentials, in the Ory namespace. |

--- a/kubernetes/modules/ory-stack/main.tf
+++ b/kubernetes/modules/ory-stack/main.tf
@@ -457,6 +457,12 @@ resource "kubernetes_network_policy_v1" "materialize_to_ory_egress" {
       }
     }
   }
+
+  # Wait for the materialize namespace to exist. console_https_lb already
+  # depends on var.materialize_instance_resource_id (which references the
+  # caller's materialize_instance module), so this chains the dep without
+  # the module having to know about materialize_instance directly.
+  depends_on = [kubernetes_service_v1.console_https_lb]
 }
 
 # Allow Ory pods to receive traffic from Materialize, from within the ory

--- a/kubernetes/modules/ory-stack/outputs.tf
+++ b/kubernetes/modules/ory-stack/outputs.tf
@@ -29,8 +29,8 @@ output "oauth2_client_secret_namespace" {
 }
 
 output "oauth2_client_id" {
-  description = "Hydra-Maester-generated OAuth2 client ID for Materialize. Null when materialize_namespace is not set."
-  value       = local.wire_materialize ? data.kubernetes_secret_v1.oauth2_client[0].data["CLIENT_ID"] : null
+  description = "Hydra-Maester-generated OAuth2 client ID for Materialize. Null when materialize_namespace is not set, or when the secret has not yet been populated by Hydra Maester (which can happen on a refresh that runs before Maester reconciles)."
+  value       = local.wire_materialize ? try(data.kubernetes_secret_v1.oauth2_client[0].data["CLIENT_ID"], null) : null
   sensitive   = true
 }
 


### PR DESCRIPTION
Two small reliability fixes that we hit while testing the GCP enterprise example end to end:

1. The `materialize_to_ory_egress` NetworkPolicy is created in `var.materialize_namespace`, but nothing inside ory-stack was waiting for that namespace to exist. The namespace is created by the caller's `materialize_instance` module, so the first apply would error with `namespaces "materialize-environment" not found` and only succeed on the second run. Chaining the NetworkPolicy on `kubernetes_service_v1.console_https_lb` (which already depends on `var.materialize_instance_resource_id`) gives the right dep without ory-stack having to reach for the caller's module.
2. The `oauth2_client_id` output indexes into `data.kubernetes_secret_v1.oauth2_client[0].data["CLIENT_ID"]` directly. If a refresh runs before Hydra Maester has populated the Secret, the data field is null and any terraform command (including destroy) errors out. Wrapped in `try(...)`.