### PR TITLE
Azure enterprise: bump to Postgres 18 + rephrase balancerd hostname blurb

### DIFF
--- a/azure/examples/enterprise/README.md
+++ b/azure/examples/enterprise/README.md
@@ -68,7 +68,7 @@ tags = {
 - `tags`: Map of tags to apply to resources
 - `license_key`: Materialize license key JWT. Used for Materialize itself and as the password authenticating to the Ory registry proxy. Must carry the `ory` entitlement.
 - `k8s_apiserver_authorized_networks`: List of CIDR blocks allowed to reach the AKS API server. No default; pass `["0.0.0.0/0"]` for lab use, or a tight allowlist for production.
-- `ory_hydra_hostname`, `ory_ui_hostname`, `ory_kratos_hostname`, `materialize_console_hostname`, `materialize_balancerd_hostname`: Public hostnames for the five browser-facing endpoints (Hydra OAuth2, Kratos public API, selfservice UI, Materialize console, and balancerd — the SQL wire endpoint the console JS calls from the browser)
+- `ory_hydra_hostname`, `ory_ui_hostname`, `ory_kratos_hostname`, `materialize_console_hostname`, `materialize_balancerd_hostname`: Public hostnames for the five browser-facing endpoints (Hydra OAuth2, Kratos public API, selfservice UI, Materialize console, and balancerd, which serves the SQL-over-HTTP endpoint the console JS calls from the browser)
 
 **Optional Variables:**
 - `location`: Azure region for deployment (defaults to `westus2`)

--- a/azure/examples/enterprise/main.tf
+++ b/azure/examples/enterprise/main.tf
@@ -69,7 +69,7 @@ locals {
 
   database_config = {
     sku_name                      = "GP_Standard_D2s_v3"
-    postgres_version              = "17"
+    postgres_version              = "18"
     storage_mb                    = 32768
     backup_retention_days         = 35
     administrator_login           = "materialize"
@@ -81,7 +81,7 @@ locals {
   # Ory database configuration (separate Postgres instance)
   ory_database_config = {
     sku_name                      = "B_Standard_B1ms"
-    postgres_version              = "17"
+    postgres_version              = "18"
     storage_mb                    = 32768
     backup_retention_days         = 35
     administrator_login           = "oryadmin"


### PR DESCRIPTION
Two follow-ups to PR #167 surfaced post-merge:

1. Per [the Azure announcement](https://techcommunity.microsoft.com/blog/adforpostgresql/postgresql-18-now-ga-on-azure-postgres-flexible-server/4469802), PostgreSQL 18 is now GA on Azure Database for PostgreSQL Flexible Server. The README's "What Gets Created" section already advertised "Version 18", but the actual `database_config.postgres_version` and `ory_database_config.postgres_version` were still pinned to 17 from the original review round. Bumping both to 18 so the example matches its own docs.
2. Reviewer nit on the balancerd hostname description: balancerd's browser-facing endpoint is SQL-over-HTTP, not the raw Postgres wire protocol. Rephrased to make that explicit.

## Test plan

- [ ] Apply the enterprise example end to end and confirm both Flexible Server instances come up on PG 18.