### PR TITLE
switch to Standard_D4ps_v5 for azure default node pool

### DIFF
--- a/azure/examples/simple/main.tf
+++ b/azure/examples/simple/main.tf
@@ -176,7 +176,7 @@ module "aks" {
   api_server_subnet_id               = module.networking.api_server_subnet_id
 
   # Default node pool with autoscaling (runs all workloads except Materialize)
-  default_node_pool_vm_size             = "Standard_D4pds_v6"
+  default_node_pool_vm_size             = "Standard_D4ps_v5"
   default_node_pool_enable_auto_scaling = true
   default_node_pool_min_count           = 2
   default_node_pool_max_count           = 5


### PR DESCRIPTION
Switch to Standard_D4ps_v5 for azure default node pool.

It is likely more widely available, we don't need local NVME disks for the default node pool, and there is nothing performance critical on those nodes.

This should fix the availability issues seen in https://github.com/MaterializeInc/materialize-terraform-self-managed/actions/runs/26824693413
Resolves https://linear.app/materializeinc/issue/CLO-88/azure-ci-aks-node-vm-size-capacity-failure