### PR TITLE
Manage default network ACL in networking module

### DIFF
--- a/aws/modules/networking/main.tf
+++ b/aws/modules/networking/main.tf
@@ -17,6 +17,13 @@ module "vpc" {
   enable_dns_hostnames = true
   enable_dns_support   = true
 
+  # Adopt the AWS-default network ACL and apply our tags so that the BYOC
+  # permissions boundary's ResourceTag-gated allow for `ec2:Delete*` (and
+  # `ec2:*NetworkAclEntry`) matches at destroy time.  Upstream defaults
+  # `manage_default_network_acl` to false, which leaves the ACL untagged
+  # and destroy calls fail with UnauthorizedOperation.
+  manage_default_network_acl = true
+
   # needed for EKS Cluster private endpoint
   # https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html#cluster-endpoint-private
   enable_dhcp_options              = true


### PR DESCRIPTION
Sets `manage_default_network_acl = true` on the VPC module so the AWS-default network ACL is adopted and tagged.

Without this, the ACL stays untagged and the BYOC permissions boundary's ResourceTag-gated allow for `ec2:Delete*` / `ec2:*NetworkAclEntry` does not match at destroy time, so destroy fails with `UnauthorizedOperation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)