### PR TITLE
Escape periods in Helm nodeSelector keys

### DIFF
--- a/aws/modules/aws-lbc/main.tf
+++ b/aws/modules/aws-lbc/main.tf
@@ -325,7 +325,7 @@ resource "helm_release" "aws_load_balancer_controller" {
   dynamic "set" {
     for_each = var.node_selector
     content {
-      name  = "nodeSelector.${set.key}"
+      name  = "nodeSelector.${replace(set.key, ".", "\\.")}"
       value = set.value
     }
   }

--- a/aws/modules/ebs-csi-driver/main.tf
+++ b/aws/modules/ebs-csi-driver/main.tf
@@ -274,7 +274,7 @@ resource "helm_release" "ebs_csi_driver" {
   dynamic "set" {
     for_each = var.node_selector
     content {
-      name  = "controller.nodeSelector.${set.key}"
+      name  = "controller.nodeSelector.${replace(set.key, ".", "\\.")}"
       value = set.value
     }
   }

--- a/aws/modules/operator/main.tf
+++ b/aws/modules/operator/main.tf
@@ -263,7 +263,7 @@ resource "helm_release" "metrics_server" {
   dynamic "set" {
     for_each = var.operator_node_selector
     content {
-      name  = "nodeSelector.${set.key}"
+      name  = "nodeSelector.${replace(set.key, ".", "\\.")}"
       value = set.value
     }
   }

--- a/kubernetes/modules/cert-manager/main.tf
+++ b/kubernetes/modules/cert-manager/main.tf
@@ -23,21 +23,21 @@ resource "helm_release" "cert_manager" {
   dynamic "set" {
     for_each = var.node_selector
     content {
-      name  = "nodeSelector.${set.key}"
+      name  = "nodeSelector.${replace(set.key, ".", "\\.")}"
       value = set.value
     }
   }
   dynamic "set" {
     for_each = var.node_selector
     content {
-      name  = "webhook.nodeSelector.${set.key}"
+      name  = "webhook.nodeSelector.${replace(set.key, ".", "\\.")}"
       value = set.value
     }
   }
   dynamic "set" {
     for_each = var.node_selector
     content {
-      name  = "cainjector.nodeSelector.${set.key}"
+      name  = "cainjector.nodeSelector.${replace(set.key, ".", "\\.")}"
       value = set.value
     }
   }


### PR DESCRIPTION
Node selector keys containing dots (e.g. `topology.kubernetes.io/zone`) were passed to Helm `--set nodeSelector.<key>` unescaped, so Helm split them into nested maps. Escape the dots with `replace(set.key, ".", "\\.")` in aws-lbc, ebs-csi-driver, operator, and cert-manager modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)