### PR TITLE
Pin kubectl provider in nlb module

### DIFF
--- a/aws/modules/nlb/versions.tf
+++ b/aws/modules/nlb/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.8"
 
   required_providers {
     aws = {
@@ -17,6 +17,11 @@ terraform {
     random = {
       source  = "hashicorp/random"
       version = "~> 3.0, < 3.9.0"
+    }
+    kubectl = {
+      source = "alekc/kubectl"
+      # TODO: Unpin once fixed: https://github.com/alekc/terraform-provider-kubectl/issues/283
+      version = "~> 2.0, < 2.3"
     }
   }
 }


### PR DESCRIPTION
Pins the `alekc/kubectl` provider to `~> 2.0, < 2.3` in the nlb module and bumps `required_version` to `>= 1.8`, matching the other modules.

Pinned to work around https://github.com/alekc/terraform-provider-kubectl/issues/283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)