### PR TITLE
Set create_before_destroy on nlb target group

### DIFF
--- a/aws/modules/nlb/target/main.tf
+++ b/aws/modules/nlb/target/main.tf
@@ -23,6 +23,14 @@ resource "aws_lb_target_group" "target_group" {
     enabled = true
     type    = "source_ip"
   }
+
+  # The listener below forwards to this target group, so a destroy-then-create
+  # replacement fails with ResourceInUse (the listener still references the old
+  # ARN at delete time). Create the replacement first, let the listener and
+  # TargetGroupBinding repoint to the new ARN, then drop the old group.
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_lb_listener" "listener" {


### PR DESCRIPTION
Adds `lifecycle { create_before_destroy = true }` to the nlb target group.

The listener forwards to this target group, so a destroy-then-create replacement fails with `ResourceInUse` because the listener still references the old ARN at delete time. Creating the replacement first lets the listener and TargetGroupBinding repoint before the old group is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)