### PR TITLE
Pin kubectl provider to 2.4.0 in remaining modules

### DIFF
--- a/aws/examples/enterprise/versions.tf
+++ b/aws/examples/enterprise/versions.tf
@@ -24,7 +24,7 @@ terraform {
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = "~> 2.0"
+      version = "2.4.0"
     }
   }
 }

--- a/aws/modules/nlb/README.md
+++ b/aws/modules/nlb/README.md
@@ -5,6 +5,7 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 2.4.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0, < 3.9.0 |
 

--- a/aws/modules/nlb/versions.tf
+++ b/aws/modules/nlb/versions.tf
@@ -18,5 +18,9 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.0, < 3.9.0"
     }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "2.4.0"
+    }
   }
 }

--- a/gcp/examples/enterprise/versions.tf
+++ b/gcp/examples/enterprise/versions.tf
@@ -24,7 +24,7 @@ terraform {
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = "~> 2.0"
+      version = "2.4.0"
     }
   }
 }

--- a/kubernetes/modules/ory-stack/README.md
+++ b/kubernetes/modules/ory-stack/README.md
@@ -5,7 +5,7 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
 | <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
-| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | ~> 2.0 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 2.4.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
@@ -13,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | ~> 2.0 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | 2.4.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0 |
 
 ## Modules
@@ -28,8 +28,8 @@
 
 | Name | Type |
 |------|------|
-| [kubectl_manifest.materialize_oauth2_client](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
-| [kubectl_manifest.ory_certificate](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.materialize_oauth2_client](https://registry.terraform.io/providers/alekc/kubectl/2.4.0/docs/resources/manifest) | resource |
+| [kubectl_manifest.ory_certificate](https://registry.terraform.io/providers/alekc/kubectl/2.4.0/docs/resources/manifest) | resource |
 | [kubernetes_namespace.ory](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_network_policy_v1.materialize_to_ory_egress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy_v1) | resource |
 | [kubernetes_network_policy_v1.ory_from_materialize_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy_v1) | resource |

--- a/kubernetes/modules/ory-stack/versions.tf
+++ b/kubernetes/modules/ory-stack/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = "~> 2.0"
+      version = "2.4.0"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
Pins the `alekc/kubectl` provider to the exact `2.4.0` everywhere it was still missing or loose:

- `aws/modules/nlb/versions.tf` — was missing `kubectl` entirely, even though its `target` submodule requires it
- `aws/examples/enterprise/versions.tf` — was `~> 2.0`
- `gcp/examples/enterprise/versions.tf` — was `~> 2.0`
- `kubernetes/modules/ory-stack/versions.tf` — was `~> 2.0`

Every other module/example already pins `2.4.0`, and `lazy_load = true` is already set in every `kubectl` provider config block. This brings the stragglers in line so the whole repo resolves to a single kubectl version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)