### PR TITLE
Upgrade to grafana 13, use community helm charts

### DIFF
--- a/kubernetes/modules/grafana/README.md
+++ b/kubernetes/modules/grafana/README.md
@@ -1,7 +1,7 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.5.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0, < 2.39.0 |
@@ -10,7 +10,7 @@
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.5.0, < 2.18.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10.0, < 2.39.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0, < 3.9.0 |
@@ -22,7 +22,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [helm_release.grafana](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_config_map.dashboards](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_namespace.grafana](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
@@ -31,9 +31,10 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_admin_password"></a> [admin\_password](#input\_admin\_password) | Admin password for Grafana. If not set, a random password will be generated. | `string` | `null` | no |
-| <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Version of the Grafana helm chart | `string` | `"10.5.0"` | no |
+| <a name="input_chart_repository"></a> [chart\_repository](#input\_chart\_repository) | Helm repository URL for Grafana chart | `string` | `"https://grafana-community.github.io/helm-charts"` | no |
+| <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Version of the Grafana helm chart | `string` | `"12.4.2"` | no |
 | <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Whether to create the namespace | `bool` | `false` | no |
 | <a name="input_install_timeout"></a> [install\_timeout](#input\_install\_timeout) | Timeout for installing the Grafana helm chart, in seconds | `number` | `600` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace for Grafana | `string` | `"monitoring"` | no |
@@ -47,7 +48,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_admin_password"></a> [admin\_password](#output\_admin\_password) | Admin password for Grafana |
 | <a name="output_grafana_url"></a> [grafana\_url](#output\_grafana\_url) | Internal URL for Grafana |
 | <a name="output_namespace"></a> [namespace](#output\_namespace) | Namespace where Grafana is deployed |

--- a/kubernetes/modules/grafana/README.md
+++ b/kubernetes/modules/grafana/README.md
@@ -1,7 +1,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.5.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0, < 2.39.0 |
@@ -10,7 +10,7 @@
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.5.0, < 2.18.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10.0, < 2.39.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0, < 3.9.0 |
@@ -22,7 +22,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [helm_release.grafana](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_config_map.dashboards](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_namespace.grafana](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
@@ -31,7 +31,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_admin_password"></a> [admin\_password](#input\_admin\_password) | Admin password for Grafana. If not set, a random password will be generated. | `string` | `null` | no |
 | <a name="input_chart_repository"></a> [chart\_repository](#input\_chart\_repository) | Helm repository URL for Grafana chart | `string` | `"https://grafana-community.github.io/helm-charts"` | no |
 | <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Version of the Grafana helm chart | `string` | `"12.4.2"` | no |
@@ -48,7 +48,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_admin_password"></a> [admin\_password](#output\_admin\_password) | Admin password for Grafana |
 | <a name="output_grafana_url"></a> [grafana\_url](#output\_grafana\_url) | Internal URL for Grafana |
 | <a name="output_namespace"></a> [namespace](#output\_namespace) | Namespace where Grafana is deployed |

--- a/kubernetes/modules/grafana/main.tf
+++ b/kubernetes/modules/grafana/main.tf
@@ -94,6 +94,10 @@ locals {
             url       = var.prometheus_url
             access    = "proxy"
             isDefault = true
+            jsonData = {
+              # Must match prometheus scrape to avoid having too low of a $__rate_interval
+              timeInterval = "60s"
+            }
           }
         ]
       }

--- a/kubernetes/modules/grafana/main.tf
+++ b/kubernetes/modules/grafana/main.tf
@@ -1,5 +1,6 @@
 # Grafana module for Materialize observability
-# Uses grafana/grafana Helm chart with Materialize dashboards
+# Uses grafana-community/grafana Helm chart with Materialize dashboards
+# WARNING: unstable as of June 2026 (major changes incoming soon!)
 
 resource "kubernetes_namespace" "grafana" {
   count = var.create_namespace ? 1 : 0
@@ -115,7 +116,7 @@ locals {
 resource "helm_release" "grafana" {
   name       = "grafana"
   namespace  = var.namespace
-  repository = "https://grafana.github.io/helm-charts"
+  repository = var.chart_repository
   chart      = "grafana"
   version    = var.chart_version
   timeout    = var.install_timeout

--- a/kubernetes/modules/grafana/variables.tf
+++ b/kubernetes/modules/grafana/variables.tf
@@ -17,8 +17,8 @@ variable "chart_repository" {
   type        = string
   # oci variant: oci://ghcr.io/grafana-community/helm-charts/
   # legacy: https://grafana.github.io/helm-charts
-  default     = "https://grafana-community.github.io/helm-charts"
-  nullable    = false
+  default  = "https://grafana-community.github.io/helm-charts"
+  nullable = false
 }
 
 variable "chart_version" {

--- a/kubernetes/modules/grafana/variables.tf
+++ b/kubernetes/modules/grafana/variables.tf
@@ -12,10 +12,19 @@ variable "create_namespace" {
   nullable    = false
 }
 
+variable "chart_repository" {
+  description = "Helm repository URL for Grafana chart"
+  type        = string
+  # oci variant: oci://ghcr.io/grafana-community/helm-charts/
+  # legacy: https://grafana.github.io/helm-charts
+  default     = "https://grafana-community.github.io/helm-charts"
+  nullable    = false
+}
+
 variable "chart_version" {
   description = "Version of the Grafana helm chart"
   type        = string
-  default     = "10.5.0"
+  default     = "12.4.2"
   nullable    = false
 }
 


### PR DESCRIPTION
This upgrades the Grafana helm chart to use the grafana-community charts (which is their new home as of Jan 2026). I support changing it back via variable if needed, but generally this should be a good default.
This also upgrades the chart to 12.4.1 (which deploys Grafana 13.0.1-sec01).
This has been verified on a TF self-managed AWS/EKS cluster.
