### PR TITLE
Wire optional Polis support into the GCP enterprise example SAS-120

### DIFF
--- a/gcp/examples/enterprise/README.md
+++ b/gcp/examples/enterprise/README.md
@@ -90,9 +90,9 @@ labels = {
 - `ingress_cidr_blocks`: List of CIDR blocks allowed to reach the LoadBalancer frontends (no effect when `internal_load_balancer = true`)
 - `internal_load_balancer`: Whether to use internal LBs (defaults to `true`). Set to `false` for prod-like demos validated against real DNS.
 - `enable_observability`: Enable Prometheus and Grafana monitoring stack (defaults to `true`)
-- `enable_polis`: Deploy Ory Polis alongside Kratos and Hydra (defaults to `false`). When `true`, also set `ory_polis_fqdn` and create the corresponding DNS record. The `polis-oel` image is currently amd64-only; on arm64 clusters add a small amd64 node pool and pin Polis there via `polis_helm_values`.
+- `enable_polis`: Deploy Ory Polis alongside Kratos and Hydra (defaults to `false`). When `true`, also set `ory_polis_fqdn` and create the corresponding DNS record.
 - `ory_polis_fqdn`: Public hostname for Polis. Required when `enable_polis = true`.
-- `polis_helm_values`: Additional Helm values for the Polis chart. Most common use is `{ deployment = { nodeSelector = { workload = "polis-amd64" } }, job = { nodeSelector = { workload = "polis-amd64" } } }` to pin Polis to a dedicated amd64 node pool.
+- `polis_helm_values`: Additional Helm values for the Polis chart. Escape hatch for overriding resources, node selectors, tolerations, etc.
 - TLS certificate options (`cert_issuer_ref`, …): see [TLS Certificates](#tls-certificates) below.
 
 ### Step 2: Deploy
@@ -269,7 +269,7 @@ After `terraform apply`, create A records for your hostnames (Hydra, Kratos, sel
 - Both Ory components are scheduled on generic nodes (not the Materialize-dedicated node pool)
 - Cloud SQL on GCP has PostgreSQL extensions (pg_trgm, btree_gin, uuid-ossp) available by default, no allowlisting needed
 - For production, override Kratos and Hydra chart values via `kratos_helm_values` and `hydra_helm_values` on the `module.ory` call (they deep-merge on top of the baked-in defaults), and register additional OAuth2 clients via Hydra Maester CRDs (Maester is enabled by default)
-- When `enable_polis = true`, the Polis Helm chart and image are pulled through the Materialize OEL registry proxy using the same license-key JWT; no additional credential is required. The `polis-oel` image is currently amd64-only; on arm64 clusters provision a small amd64 node pool and pin Polis there via `polis_helm_values`
+- When `enable_polis = true`, the Polis Helm chart and image are pulled through the Materialize OEL registry proxy using the same license-key JWT; no additional credential is required
 - Don't forget to destroy resources when finished:
 
 ```bash

--- a/gcp/examples/enterprise/README.md
+++ b/gcp/examples/enterprise/README.md
@@ -1,6 +1,6 @@
 # Example: Enterprise Materialize Deployment on GCP with Ory (OIDC/SAML)
 
-This example extends the [simple deployment](../simple/) with **Ory Kratos** (identity management) and **Ory Hydra** (OAuth2/OIDC provider) for enterprise authentication via OIDC and SAML.
+This example extends the [simple deployment](../simple/) with **Ory Kratos** (identity management) and **Ory Hydra** (OAuth2/OIDC provider) for enterprise authentication via OIDC and SAML. Optionally adds **Ory Polis** (SAML-to-OIDC bridge with SCIM support) when `enable_polis = true`.
 
 Ory enterprise images are pulled through the Materialize-hosted registry proxy at `ory.registry.cloud.materialize.com`. The proxy authenticates with the Materialize license key JWT, so no separate Ory credential is needed. Cluster nodes need egress to the proxy host and to `storage.googleapis.com` (the proxy returns 307 redirects to signed GCS URLs for blob GETs, which the kubelet follows directly).
 
@@ -11,9 +11,9 @@ Ory enterprise images are pulled through the Materialize-hosted registry proxy a
 Everything from the [simple example](../simple/README.md), plus:
 
 ### Ory Database
-- **Cloud SQL for PostgreSQL** (separate instance from Materialize): Version 17
+- **Cloud SQL for PostgreSQL** (separate instance from Materialize): Version 18
 - **Tier**: db-f1-micro (suitable for Ory workloads)
-- **Databases**: `kratos` and `hydra` on the same instance
+- **Databases**: `kratos` and `hydra` on the same instance (plus `polis` when `enable_polis = true`)
 - **Network Access**: Private IP only, same VPC as the Materialize database
 
 ### Ory Kratos (Identity Management)
@@ -28,6 +28,12 @@ Everything from the [simple example](../simple/README.md), plus:
 - **Resources**: 250m CPU request / 256Mi memory (request & limit)
 - **Maester**: Enabled (CRD controller for managing OAuth2 clients via Kubernetes resources)
 - **Purpose**: Issues OAuth2 tokens, provides OIDC discovery endpoint, delegates login/consent to Kratos
+
+### Ory Polis (optional, SAML-to-OIDC bridge)
+- **Helm release**: Deployed in the `ory` namespace when `enable_polis = true`
+- **Purpose**: Accepts a customer's SAML IdP on one side and exposes an OIDC provider on the other so Kratos can consume it as an upstream social sign-in. Also exposes a SCIM endpoint for IdP-driven user provisioning.
+- **Chart and image**: Both pulled through the Materialize OEL registry proxy with the license-key JWT, no separate credential required
+- Off by default. Set `enable_polis = true` and `ory_polis_fqdn` to deploy.
 
 ---
 
@@ -84,6 +90,9 @@ labels = {
 - `ingress_cidr_blocks`: List of CIDR blocks allowed to reach the LoadBalancer frontends (no effect when `internal_load_balancer = true`)
 - `internal_load_balancer`: Whether to use internal LBs (defaults to `true`). Set to `false` for prod-like demos validated against real DNS.
 - `enable_observability`: Enable Prometheus and Grafana monitoring stack (defaults to `true`)
+- `enable_polis`: Deploy Ory Polis alongside Kratos and Hydra (defaults to `false`). When `true`, also set `ory_polis_fqdn` and create the corresponding DNS record. The `polis-oel` image is currently amd64-only; on arm64 clusters add a small amd64 node pool and pin Polis there via `polis_helm_values`.
+- `ory_polis_fqdn`: Public hostname for Polis. Required when `enable_polis = true`.
+- `polis_helm_values`: Additional Helm values for the Polis chart. Most common use is `{ deployment = { nodeSelector = { workload = "polis-amd64" } }, job = { nodeSelector = { workload = "polis-amd64" } } }` to pin Polis to a dedicated amd64 node pool.
 - TLS certificate options (`cert_issuer_ref`, …): see [TLS Certificates](#tls-certificates) below.
 
 ### Step 2: Deploy
@@ -217,7 +226,7 @@ module "materialize_enterprise" {
 }
 ```
 
-After `terraform apply`, create A records for your hostnames (Hydra, Kratos, selfservice UI, Materialize console) pointing at the LB IPs. cert-manager issues certs once DNS resolves (typically 1 to 2 minutes for the first issuance).
+After `terraform apply`, create A records for your hostnames (Hydra, Kratos, selfservice UI, Materialize console, and Polis when `enable_polis = true`) pointing at the LB IPs. cert-manager issues certs once DNS resolves (typically 1 to 2 minutes for the first issuance).
 
 ---
 
@@ -260,6 +269,7 @@ After `terraform apply`, create A records for your hostnames (Hydra, Kratos, sel
 - Both Ory components are scheduled on generic nodes (not the Materialize-dedicated node pool)
 - Cloud SQL on GCP has PostgreSQL extensions (pg_trgm, btree_gin, uuid-ossp) available by default, no allowlisting needed
 - For production, override Kratos and Hydra chart values via `kratos_helm_values` and `hydra_helm_values` on the `module.ory` call (they deep-merge on top of the baked-in defaults), and register additional OAuth2 clients via Hydra Maester CRDs (Maester is enabled by default)
+- When `enable_polis = true`, the Polis Helm chart and image are pulled through the Materialize OEL registry proxy using the same license-key JWT; no additional credential is required. The `polis-oel` image is currently amd64-only; on arm64 clusters provision a small amd64 node pool and pin Polis there via `polis_helm_values`
 - Don't forget to destroy resources when finished:
 
 ```bash

--- a/gcp/examples/enterprise/main.tf
+++ b/gcp/examples/enterprise/main.tf
@@ -508,10 +508,7 @@ module "ory" {
   kratos_dsn = local.ory_kratos_dsn
   hydra_dsn  = local.ory_hydra_dsn
 
-  # Polis (SAML-to-OIDC bridge). Off by default; turn on to let customers wire
-  # a SAML IdP that Kratos can consume as an upstream OIDC provider. Both the
-  # Polis chart and image are pulled through the Materialize OEL registry proxy
-  # using the license-key JWT, no separate credential required.
+  # Polis (SAML-to-OIDC bridge). Off by default.
   enable_polis = var.enable_polis
   polis_fqdn   = var.enable_polis ? var.ory_polis_fqdn : null
   polis_dsn    = var.enable_polis ? local.ory_polis_dsn : null

--- a/gcp/examples/enterprise/main.tf
+++ b/gcp/examples/enterprise/main.tf
@@ -166,6 +166,14 @@ locals {
     "hydra"
   )
 
+  ory_polis_dsn = format(
+    "postgres://%s:%s@%s/%s?sslmode=require",
+    module.ory_database.users[0].name,
+    urlencode(module.ory_database.users[0].password),
+    module.ory_database.private_ip,
+    "polis"
+  )
+
   ory_namespace = "ory"
 
   # cert-manager ClusterIssuer for browser-facing TLS. Defaults to the built-in
@@ -290,10 +298,15 @@ module "database" {
 module "ory_database" {
   source = "../../modules/database"
 
-  databases = [
-    { name = "kratos", charset = "UTF8", collation = "en_US.UTF8" },
-    { name = "hydra", charset = "UTF8", collation = "en_US.UTF8" }
-  ]
+  databases = concat(
+    [
+      { name = "kratos", charset = "UTF8", collation = "en_US.UTF8" },
+      { name = "hydra", charset = "UTF8", collation = "en_US.UTF8" },
+    ],
+    var.enable_polis ? [
+      { name = "polis", charset = "UTF8", collation = "en_US.UTF8" },
+    ] : []
+  )
   users = [{ name = local.ory_database_config.user_name }]
 
   project_id = var.project_id
@@ -494,6 +507,16 @@ module "ory" {
 
   kratos_dsn = local.ory_kratos_dsn
   hydra_dsn  = local.ory_hydra_dsn
+
+  # Polis (SAML-to-OIDC bridge). Off by default; turn on to let customers wire
+  # a SAML IdP that Kratos can consume as an upstream OIDC provider. Both the
+  # Polis chart and image are pulled through the Materialize OEL registry proxy
+  # using the license-key JWT, no separate credential required.
+  enable_polis = var.enable_polis
+  polis_fqdn   = var.enable_polis ? var.ory_polis_fqdn : null
+  polis_dsn    = var.enable_polis ? local.ory_polis_dsn : null
+
+  polis_helm_values = var.polis_helm_values
 
   oel_registry    = var.ory_oel_registry
   oel_image_tag   = var.ory_oel_image_tag

--- a/gcp/examples/enterprise/outputs.tf
+++ b/gcp/examples/enterprise/outputs.tf
@@ -183,12 +183,13 @@ output "ory_database_private_ip" {
 }
 
 output "ory" {
-  description = "Ory stack deployment details (Hydra issuer URL, Kratos and UI external URLs, OAuth2 client secret name)."
+  description = "Ory stack deployment details (Hydra issuer URL, Kratos and UI external URLs, OAuth2 client secret name, optional Polis URL)."
   value = {
     namespace                 = module.ory.namespace
     hydra_external_url        = module.ory.hydra_external_url
     kratos_external_url       = module.ory.kratos_external_url
     ui_external_url           = module.ory.ui_external_url
+    polis_external_url        = module.ory.polis_external_url
     oauth2_client_secret_name = module.ory.oauth2_client_secret_name
   }
 }

--- a/gcp/examples/enterprise/terraform.tfvars.example
+++ b/gcp/examples/enterprise/terraform.tfvars.example
@@ -24,15 +24,8 @@ materialize_balancerd_fqdn = "balancerd.mz.example.com"
 
 # Optional: deploy Ory Polis (SAML-to-OIDC bridge). When true, set
 # ory_polis_fqdn and point an A record at the polis LB IP after apply.
-# Both the Polis chart and image are pulled through the Materialize OEL
+# The Polis chart and image are pulled through the Materialize OEL
 # registry proxy using the license-key JWT above, no extra credential needed.
-# The polis-oel image is currently amd64-only, so on arm64 clusters add a
-# dedicated amd64 node pool out of band and pin Polis there:
-#
-#   polis_helm_values = {
-#     deployment = { nodeSelector = { workload = "polis-amd64" } }
-#     job        = { nodeSelector = { workload = "polis-amd64" } }
-#   }
 #
 # enable_polis   = true
 # ory_polis_fqdn = "polis.mz.example.com"

--- a/gcp/examples/enterprise/terraform.tfvars.example
+++ b/gcp/examples/enterprise/terraform.tfvars.example
@@ -22,6 +22,21 @@ ory_kratos_fqdn            = "kratos.mz.example.com"
 materialize_console_fqdn   = "console.mz.example.com"
 materialize_balancerd_fqdn = "balancerd.mz.example.com"
 
+# Optional: deploy Ory Polis (SAML-to-OIDC bridge). When true, set
+# ory_polis_fqdn and point an A record at the polis LB IP after apply.
+# Both the Polis chart and image are pulled through the Materialize OEL
+# registry proxy using the license-key JWT above, no extra credential needed.
+# The polis-oel image is currently amd64-only, so on arm64 clusters add a
+# dedicated amd64 node pool out of band and pin Polis there:
+#
+#   polis_helm_values = {
+#     deployment = { nodeSelector = { workload = "polis-amd64" } }
+#     job        = { nodeSelector = { workload = "polis-amd64" } }
+#   }
+#
+# enable_polis   = true
+# ory_polis_fqdn = "polis.mz.example.com"
+
 # Optional: bring your own cert-manager (Cluster)Issuer for browser-facing
 # TLS. Leave commented out to use the in-cluster self-signed issuer (browser
 # trust warnings). See the README for a Let's Encrypt + Cloudflare snippet.

--- a/gcp/examples/enterprise/variables.tf
+++ b/gcp/examples/enterprise/variables.tf
@@ -107,7 +107,7 @@ variable "ory_oel_registry" {
 variable "ory_oel_image_tag" {
   description = "Image tag for OEL images."
   type        = string
-  default     = "26.2.3"
+  default     = "26.2.22"
 }
 
 variable "ory_hydra_fqdn" {
@@ -139,7 +139,7 @@ variable "ory_polis_fqdn" {
 }
 
 variable "polis_helm_values" {
-  description = "Additional Helm values deep-merged into the Polis chart. Common case is pinning Polis pods to a particular node pool (e.g. amd64) while the rest of the Ory stack stays on the generic pool."
+  description = "Additional Helm values deep-merged into the Polis chart. Escape hatch for overriding resources, node selectors, tolerations, etc."
   type        = any
   default     = {}
 }

--- a/gcp/examples/enterprise/variables.tf
+++ b/gcp/examples/enterprise/variables.tf
@@ -125,6 +125,25 @@ variable "ory_kratos_fqdn" {
   type        = string
 }
 
+variable "enable_polis" {
+  description = "Deploy Ory Polis (SAML-to-OIDC bridge) alongside Kratos and Hydra. When true, ory_polis_fqdn must be set and a polis database is provisioned on the Ory Cloud SQL instance."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "ory_polis_fqdn" {
+  description = "External hostname for Ory Polis (SAML-to-OIDC bridge). Used as the NEXTAUTH_URL so SAML and OAuth callbacks redirect through it. Required when enable_polis is true. Example: polis.internal.example.com"
+  type        = string
+  default     = null
+}
+
+variable "polis_helm_values" {
+  description = "Additional Helm values deep-merged into the Polis chart. Common case is pinning Polis pods to a particular node pool (e.g. amd64) while the rest of the Ory stack stays on the generic pool."
+  type        = any
+  default     = {}
+}
+
 variable "materialize_console_fqdn" {
   description = "External hostname for the Materialize console. Used to construct the OAuth2 redirect URI. Example: materialize.internal.example.com"
   type        = string


### PR DESCRIPTION
Mirrors the Azure Polis wiring into the GCP enterprise example, off by default behind enable_polis.

Fixes https://linear.app/materializeinc/issue/DEP-146/wire-enable-polis-into-the-gcp-enterprise-example