### PR TITLE
Wire optional Polis support into the AWS enterprise example SAS-121

### DIFF
--- a/aws/examples/enterprise/README.md
+++ b/aws/examples/enterprise/README.md
@@ -33,7 +33,6 @@ Everything from the [simple example](../simple/README.md), plus:
 - **Helm release**: Deployed in the `ory` namespace when `enable_polis = true`
 - **Purpose**: Accepts a customer's SAML IdP on one side and exposes an OIDC provider on the other so Kratos can consume it as an upstream social sign-in. Also exposes a SCIM endpoint for IdP-driven user provisioning.
 - **Chart and image**: Both pulled through the Materialize OEL registry proxy with the license-key JWT, no separate credential required
-- **Node scheduling**: The `polis-oel` image is amd64-only and the example's generic Karpenter nodepool defaults to arm64 (t4g). Provision a small amd64 nodepool out of band and pin Polis there via `polis_helm_values`.
 - Off by default. Set `enable_polis = true` and `ory_polis_fqdn` to deploy.
 
 ---
@@ -85,9 +84,9 @@ tags = {
 - `ingress_cidr_blocks`: List of CIDR blocks allowed to reach the NLB (no effect when `internal_load_balancer = true`)
 - `internal_load_balancer`: Whether to use an internal load balancer (defaults to `true`). Set to `false` for prod-like demos validated against real DNS.
 - `enable_observability`: Enable Prometheus and Grafana monitoring stack (defaults to `true`)
-- `enable_polis`: Deploy Ory Polis alongside Kratos and Hydra (defaults to `false`). When `true`, also set `ory_polis_fqdn` and create the corresponding DNS record. A dedicated RDS instance is provisioned for the polis database. The `polis-oel` image is amd64-only and this example's generic Karpenter nodepool defaults to arm64, so add an amd64 nodepool out of band and pin Polis there via `polis_helm_values`.
+- `enable_polis`: Deploy Ory Polis alongside Kratos and Hydra (defaults to `false`). When `true`, also set `ory_polis_fqdn` and create the corresponding DNS record. A dedicated RDS instance is provisioned for the polis database.
 - `ory_polis_fqdn`: Public hostname for Polis. Required when `enable_polis = true`.
-- `polis_helm_values`: Additional Helm values for the Polis chart. Typical use is `{ deployment = { nodeSelector = { workload = "polis-amd64" } }, job = { nodeSelector = { workload = "polis-amd64" } } }` to pin Polis to a dedicated amd64 nodepool.
+- `polis_helm_values`: Additional Helm values for the Polis chart. Escape hatch for overriding resources, node selectors, tolerations, etc.
 - TLS certificate options (`cert_issuer_ref`, …): see [TLS Certificates](#tls-certificates) below.
 
 ### Step 2: Deploy
@@ -264,7 +263,7 @@ After `terraform apply`, create CNAME (or ALIAS) records for your hostnames (Hyd
 - Kratos and Hydra are scheduled on the generic Karpenter nodepool (not the Materialize-dedicated nodepool)
 - AWS RDS has PostgreSQL extensions (pg_trgm, btree_gin, uuid-ossp) available by default
 - For production, override Kratos and Hydra chart values via `kratos_helm_values` and `hydra_helm_values` on the `module.ory` call (they deep-merge on top of the baked-in defaults), and register additional OAuth2 clients via Hydra Maester CRDs (Maester is enabled by default)
-- When `enable_polis = true`, the Polis Helm chart and image are pulled through the Materialize OEL registry proxy using the same license-key JWT; no additional credential is required. The `polis-oel` image is currently amd64-only and the generic nodepool defaults to arm64 (t4g), so provision a small amd64 nodepool out of band and pin Polis there via `polis_helm_values`
+- When `enable_polis = true`, the Polis Helm chart and image are pulled through the Materialize OEL registry proxy using the same license-key JWT; no additional credential is required
 - Don't forget to destroy resources when finished:
 
 ```bash

--- a/aws/examples/enterprise/README.md
+++ b/aws/examples/enterprise/README.md
@@ -11,7 +11,7 @@ Ory enterprise images are pulled through the Materialize-hosted registry proxy a
 Everything from the [simple example](../simple/README.md), plus:
 
 ### Ory Databases
-- **Two separate RDS instances** (one for Kratos, one for Hydra): PostgreSQL 18
+- **Separate RDS instances** (one per Ory component): PostgreSQL 18. Kratos and Hydra always, Polis added when `enable_polis = true`.
 - **Instance class**: db.t3.small (suitable for Ory workloads)
 - **Storage**: 20GB with autoscaling up to 50GB
 - **Network Access**: Private subnets only, same VPC as the Materialize database
@@ -28,6 +28,13 @@ Everything from the [simple example](../simple/README.md), plus:
 - **Resources**: 250m CPU request / 256Mi memory (request & limit)
 - **Maester**: Enabled (CRD controller for managing OAuth2 clients via Kubernetes resources)
 - **Purpose**: Issues OAuth2 tokens, provides OIDC discovery endpoint, delegates login/consent to Kratos
+
+### Ory Polis (optional, SAML-to-OIDC bridge)
+- **Helm release**: Deployed in the `ory` namespace when `enable_polis = true`
+- **Purpose**: Accepts a customer's SAML IdP on one side and exposes an OIDC provider on the other so Kratos can consume it as an upstream social sign-in. Also exposes a SCIM endpoint for IdP-driven user provisioning.
+- **Chart and image**: Both pulled through the Materialize OEL registry proxy with the license-key JWT, no separate credential required
+- **Node scheduling**: The `polis-oel` image is amd64-only and the example's generic Karpenter nodepool defaults to arm64 (t4g). Provision a small amd64 nodepool out of band and pin Polis there via `polis_helm_values`.
+- Off by default. Set `enable_polis = true` and `ory_polis_fqdn` to deploy.
 
 ---
 
@@ -78,6 +85,9 @@ tags = {
 - `ingress_cidr_blocks`: List of CIDR blocks allowed to reach the NLB (no effect when `internal_load_balancer = true`)
 - `internal_load_balancer`: Whether to use an internal load balancer (defaults to `true`). Set to `false` for prod-like demos validated against real DNS.
 - `enable_observability`: Enable Prometheus and Grafana monitoring stack (defaults to `true`)
+- `enable_polis`: Deploy Ory Polis alongside Kratos and Hydra (defaults to `false`). When `true`, also set `ory_polis_fqdn` and create the corresponding DNS record. A dedicated RDS instance is provisioned for the polis database. The `polis-oel` image is amd64-only and this example's generic Karpenter nodepool defaults to arm64, so add an amd64 nodepool out of band and pin Polis there via `polis_helm_values`.
+- `ory_polis_fqdn`: Public hostname for Polis. Required when `enable_polis = true`.
+- `polis_helm_values`: Additional Helm values for the Polis chart. Typical use is `{ deployment = { nodeSelector = { workload = "polis-amd64" } }, job = { nodeSelector = { workload = "polis-amd64" } } }` to pin Polis to a dedicated amd64 nodepool.
 - TLS certificate options (`cert_issuer_ref`, …): see [TLS Certificates](#tls-certificates) below.
 
 ### Step 2: Deploy
@@ -211,7 +221,7 @@ module "materialize_enterprise" {
 }
 ```
 
-After `terraform apply`, create A records for your hostnames (Hydra, Kratos, selfservice UI, Materialize console) pointing at the LB IPs. cert-manager issues certs once DNS resolves (typically 1 to 2 minutes for the first issuance).
+After `terraform apply`, create CNAME (or ALIAS) records for your hostnames (Hydra, Kratos, selfservice UI, Materialize console, and Polis when `enable_polis = true`) pointing at the NLB DNS names. cert-manager issues certs once DNS resolves (typically 1 to 2 minutes for the first issuance).
 
 ---
 
@@ -249,11 +259,12 @@ After `terraform apply`, create A records for your hostnames (Hydra, Kratos, sel
 
 ## Notes
 
-- AWS RDS creates one database per instance, so Kratos and Hydra each get their own RDS instance (`db.t3.small`)
-- Both Ory components share the `ory` namespace but have separate databases
-- Both Ory components are scheduled on generic Karpenter nodes (not the Materialize-dedicated node pool)
+- AWS RDS creates one database per instance, so each Ory component (Kratos, Hydra, and Polis when enabled) gets its own RDS instance (`db.t3.small`)
+- All Ory components share the `ory` namespace but use separate databases
+- Kratos and Hydra are scheduled on the generic Karpenter nodepool (not the Materialize-dedicated nodepool)
 - AWS RDS has PostgreSQL extensions (pg_trgm, btree_gin, uuid-ossp) available by default
 - For production, override Kratos and Hydra chart values via `kratos_helm_values` and `hydra_helm_values` on the `module.ory` call (they deep-merge on top of the baked-in defaults), and register additional OAuth2 clients via Hydra Maester CRDs (Maester is enabled by default)
+- When `enable_polis = true`, the Polis Helm chart and image are pulled through the Materialize OEL registry proxy using the same license-key JWT; no additional credential is required. The `polis-oel` image is currently amd64-only and the generic nodepool defaults to arm64 (t4g), so provision a small amd64 nodepool out of band and pin Polis there via `polis_helm_values`
 - Don't forget to destroy resources when finished:
 
 ```bash

--- a/aws/examples/enterprise/main.tf
+++ b/aws/examples/enterprise/main.tf
@@ -404,9 +404,7 @@ module "ory_hydra_database" {
   tags = var.tags
 }
 
-# Separate RDS instance for Ory Polis (only when enable_polis = true). The
-# AWS database module is one-DB-per-instance, so Polis gets its own RDS like
-# Kratos and Hydra.
+# Separate RDS instance for Ory Polis (one-DB-per-instance).
 module "ory_polis_database" {
   count  = var.enable_polis ? 1 : 0
   source = "../../modules/database"
@@ -577,13 +575,8 @@ module "ory" {
   kratos_dsn = local.ory_kratos_dsn
   hydra_dsn  = local.ory_hydra_dsn
 
-  # Polis (SAML-to-OIDC bridge). Off by default; turn on to let customers wire
-  # a SAML IdP that Kratos can consume as an upstream OIDC provider. Both the
-  # Polis chart and image are pulled through the Materialize OEL registry proxy
-  # using the license-key JWT, no separate credential required. The polis-oel
-  # image is amd64-only, so on this example's default arm64 generic nodepool
-  # callers must provision a small amd64 nodepool and pin Polis there via
-  # polis_helm_values.
+  # Polis (SAML-to-OIDC bridge). Off by default; pin to an amd64 nodepool via
+  # polis_helm_values since polis-oel is amd64-only.
   enable_polis = var.enable_polis
   polis_fqdn   = var.enable_polis ? var.ory_polis_fqdn : null
   polis_dsn    = local.ory_polis_dsn

--- a/aws/examples/enterprise/main.tf
+++ b/aws/examples/enterprise/main.tf
@@ -575,8 +575,7 @@ module "ory" {
   kratos_dsn = local.ory_kratos_dsn
   hydra_dsn  = local.ory_hydra_dsn
 
-  # Polis (SAML-to-OIDC bridge). Off by default; pin to an amd64 nodepool via
-  # polis_helm_values since polis-oel is amd64-only.
+  # Polis (SAML-to-OIDC bridge). Off by default.
   enable_polis = var.enable_polis
   polis_fqdn   = var.enable_polis ? var.ory_polis_fqdn : null
   polis_dsn    = local.ory_polis_dsn

--- a/aws/examples/enterprise/main.tf
+++ b/aws/examples/enterprise/main.tf
@@ -404,6 +404,32 @@ module "ory_hydra_database" {
   tags = var.tags
 }
 
+# Separate RDS instance for Ory Polis (only when enable_polis = true). The
+# AWS database module is one-DB-per-instance, so Polis gets its own RDS like
+# Kratos and Hydra.
+module "ory_polis_database" {
+  count  = var.enable_polis ? 1 : 0
+  source = "../../modules/database"
+
+  name_prefix               = "${var.name_prefix}-ory-polis"
+  postgres_version          = "18"
+  backup_retention_period   = 35
+  instance_class            = "db.t3.small"
+  allocated_storage         = 20
+  max_allocated_storage     = 50
+  database_name             = "polis"
+  database_username         = "oryadmin"
+  database_password         = random_password.ory_database_password.result
+  multi_az                  = false
+  database_subnet_ids       = module.networking.private_subnet_ids
+  vpc_id                    = module.networking.vpc_id
+  cluster_name              = module.eks.cluster_name
+  cluster_security_group_id = module.eks.cluster_security_group_id
+  node_security_group_id    = module.eks.node_security_group_id
+
+  tags = var.tags
+}
+
 # 8. Setup S3 bucket for Materialize
 module "storage" {
   source                 = "../../modules/storage"
@@ -550,6 +576,19 @@ module "ory" {
 
   kratos_dsn = local.ory_kratos_dsn
   hydra_dsn  = local.ory_hydra_dsn
+
+  # Polis (SAML-to-OIDC bridge). Off by default; turn on to let customers wire
+  # a SAML IdP that Kratos can consume as an upstream OIDC provider. Both the
+  # Polis chart and image are pulled through the Materialize OEL registry proxy
+  # using the license-key JWT, no separate credential required. The polis-oel
+  # image is amd64-only, so on this example's default arm64 generic nodepool
+  # callers must provision a small amd64 nodepool and pin Polis there via
+  # polis_helm_values.
+  enable_polis = var.enable_polis
+  polis_fqdn   = var.enable_polis ? var.ory_polis_fqdn : null
+  polis_dsn    = local.ory_polis_dsn
+
+  polis_helm_values = var.polis_helm_values
 
   oel_registry    = var.ory_oel_registry
   oel_image_tag   = var.ory_oel_image_tag
@@ -706,6 +745,14 @@ locals {
     module.ory_hydra_database.db_instance_endpoint,
     "hydra"
   )
+
+  ory_polis_dsn = var.enable_polis ? format(
+    "postgres://%s:%s@%s/%s?sslmode=require",
+    module.ory_polis_database[0].db_instance_username,
+    urlencode(random_password.ory_database_password.result),
+    module.ory_polis_database[0].db_instance_endpoint,
+    "polis"
+  ) : null
 
   ory_namespace = "ory"
 

--- a/aws/examples/enterprise/outputs.tf
+++ b/aws/examples/enterprise/outputs.tf
@@ -155,13 +155,19 @@ output "ory_hydra_database_endpoint" {
   value       = module.ory_hydra_database.db_instance_endpoint
 }
 
+output "ory_polis_database_endpoint" {
+  description = "RDS instance endpoint for Ory Polis (null when enable_polis = false)"
+  value       = var.enable_polis ? module.ory_polis_database[0].db_instance_endpoint : null
+}
+
 output "ory" {
-  description = "Ory stack deployment details (Hydra issuer URL, Kratos and UI external URLs, OAuth2 client secret name)."
+  description = "Ory stack deployment details (Hydra issuer URL, Kratos and UI external URLs, OAuth2 client secret name, optional Polis URL)."
   value = {
     namespace                 = module.ory.namespace
     hydra_external_url        = module.ory.hydra_external_url
     kratos_external_url       = module.ory.kratos_external_url
     ui_external_url           = module.ory.ui_external_url
+    polis_external_url        = module.ory.polis_external_url
     oauth2_client_secret_name = module.ory.oauth2_client_secret_name
   }
 }

--- a/aws/examples/enterprise/terraform.tfvars.example
+++ b/aws/examples/enterprise/terraform.tfvars.example
@@ -17,19 +17,10 @@ materialize_console_fqdn   = "console.mz.example.com"
 materialize_balancerd_fqdn = "balancerd.mz.example.com"
 
 # Optional: deploy Ory Polis (SAML-to-OIDC bridge). When true, set
-# ory_polis_fqdn and point an A record at the polis LB hostname after apply.
+# ory_polis_fqdn and point a CNAME at the polis LB hostname after apply.
 # A dedicated RDS instance is provisioned for the polis database. The Polis
 # chart and image are pulled through the Materialize OEL registry proxy
 # using the license-key JWT above; no extra credential needed.
-#
-# The polis-oel image is amd64-only and this example's generic Karpenter
-# nodepool defaults to arm64 (t4g) instances. Add an amd64 nodepool out of
-# band and pin Polis pods there:
-#
-#   polis_helm_values = {
-#     deployment = { nodeSelector = { workload = "polis-amd64" } }
-#     job        = { nodeSelector = { workload = "polis-amd64" } }
-#   }
 #
 # enable_polis   = true
 # ory_polis_fqdn = "polis.mz.example.com"

--- a/aws/examples/enterprise/terraform.tfvars.example
+++ b/aws/examples/enterprise/terraform.tfvars.example
@@ -16,6 +16,24 @@ ory_kratos_fqdn            = "kratos.mz.example.com"
 materialize_console_fqdn   = "console.mz.example.com"
 materialize_balancerd_fqdn = "balancerd.mz.example.com"
 
+# Optional: deploy Ory Polis (SAML-to-OIDC bridge). When true, set
+# ory_polis_fqdn and point an A record at the polis LB hostname after apply.
+# A dedicated RDS instance is provisioned for the polis database. The Polis
+# chart and image are pulled through the Materialize OEL registry proxy
+# using the license-key JWT above; no extra credential needed.
+#
+# The polis-oel image is amd64-only and this example's generic Karpenter
+# nodepool defaults to arm64 (t4g) instances. Add an amd64 nodepool out of
+# band and pin Polis pods there:
+#
+#   polis_helm_values = {
+#     deployment = { nodeSelector = { workload = "polis-amd64" } }
+#     job        = { nodeSelector = { workload = "polis-amd64" } }
+#   }
+#
+# enable_polis   = true
+# ory_polis_fqdn = "polis.mz.example.com"
+
 # Optional: bring your own cert-manager (Cluster)Issuer for browser-facing
 # TLS. Leave commented out to use the in-cluster self-signed issuer (browser
 # trust warnings). See the README for a Let's Encrypt + Cloudflare snippet.

--- a/aws/examples/enterprise/variables.tf
+++ b/aws/examples/enterprise/variables.tf
@@ -82,7 +82,7 @@ variable "ory_oel_registry" {
 variable "ory_oel_image_tag" {
   description = "Image tag for OEL images."
   type        = string
-  default     = "26.2.3"
+  default     = "26.2.22"
 }
 
 variable "ory_hydra_fqdn" {
@@ -114,7 +114,7 @@ variable "ory_polis_fqdn" {
 }
 
 variable "polis_helm_values" {
-  description = "Additional Helm values deep-merged into the Polis chart. The default generic Karpenter nodepool runs arm64 (t4g) instances and the polis-oel image is amd64-only; provision a small amd64 nodepool out of band and pin Polis there, e.g. { deployment = { nodeSelector = { workload = \"polis-amd64\" } }, job = { nodeSelector = { workload = \"polis-amd64\" } } }."
+  description = "Additional Helm values deep-merged into the Polis chart. Escape hatch for overriding resources, node selectors, tolerations, etc."
   type        = any
   default     = {}
 }

--- a/aws/examples/enterprise/variables.tf
+++ b/aws/examples/enterprise/variables.tf
@@ -100,6 +100,25 @@ variable "ory_kratos_fqdn" {
   type        = string
 }
 
+variable "enable_polis" {
+  description = "Deploy Ory Polis (SAML-to-OIDC bridge) alongside Kratos and Hydra. When true, ory_polis_fqdn must be set and a dedicated RDS instance is provisioned for the polis database."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "ory_polis_fqdn" {
+  description = "External hostname for Ory Polis (SAML-to-OIDC bridge). Used as the NEXTAUTH_URL so SAML and OAuth callbacks redirect through it. Required when enable_polis is true. Example: polis.internal.example.com"
+  type        = string
+  default     = null
+}
+
+variable "polis_helm_values" {
+  description = "Additional Helm values deep-merged into the Polis chart. The default generic Karpenter nodepool runs arm64 (t4g) instances and the polis-oel image is amd64-only; provision a small amd64 nodepool out of band and pin Polis there, e.g. { deployment = { nodeSelector = { workload = \"polis-amd64\" } }, job = { nodeSelector = { workload = \"polis-amd64\" } } }."
+  type        = any
+  default     = {}
+}
+
 variable "materialize_console_fqdn" {
   description = "External hostname for the Materialize console. Used to construct the OAuth2 redirect URI. Example: materialize.internal.example.com"
   type        = string


### PR DESCRIPTION
Mirrors the Azure and GCP Polis wiring into the AWS enterprise example, off by default behind enable_polis. Polis gets its own RDS instance since the AWS database module is one-DB-per-instance, and on this example's default arm64 nodepool callers need to provision an amd64 pool and pin Polis there.

Fixes https://linear.app/materializeinc/issue/DEP-147/wire-enable-polis-into-the-aws-enterprise-example