### PR TITLE
Bump default polis-oel image tag to 26.2.22 for multi-arch support

### DIFF
--- a/azure/examples/enterprise/variables.tf
+++ b/azure/examples/enterprise/variables.tf
@@ -80,7 +80,7 @@ variable "ory_oel_registry" {
 variable "ory_oel_image_tag" {
   description = "Image tag for OEL images."
   type        = string
-  default     = "26.2.3"
+  default     = "26.2.22"
 }
 
 variable "ory_hydra_fqdn" {
@@ -112,7 +112,7 @@ variable "ory_polis_fqdn" {
 }
 
 variable "polis_helm_values" {
-  description = "Additional Helm values deep-merged into the Polis chart. Used as an escape hatch, common case is pinning Polis pods to a particular node pool (e.g. amd64) while the rest of the Ory stack stays on the generic pool."
+  description = "Additional Helm values deep-merged into the Polis chart. Escape hatch for overriding resources, node selectors, tolerations, etc."
   type        = any
   default     = {}
 }


### PR DESCRIPTION
Default polis-oel tag bumped to 26.2.22 now that Ory ships a multi-arch (amd64 + arm64) image, so the Azure enterprise example no longer needs an amd64 nodepool workaround. Linear: DEP-145.