### PR TITLE
Pass request_rollout and force_rollout for all clouds

### DIFF
--- a/azure/examples/enterprise/main.tf
+++ b/azure/examples/enterprise/main.tf
@@ -466,6 +466,10 @@ module "materialize_instance" {
   metadata_backend_url = local.metadata_backend_url
   persist_backend_url  = local.persist_backend_url
 
+  # Rollout configuration
+  force_rollout   = var.force_rollout
+  request_rollout = var.request_rollout
+
   # Use OIDC authentication via Ory Hydra. The external_login_password is still required
   # as a fallback for the mz_system admin user.
   authenticator_kind                = "Oidc"

--- a/azure/examples/enterprise/variables.tf
+++ b/azure/examples/enterprise/variables.tf
@@ -43,6 +43,18 @@ variable "license_key" {
   sensitive   = true
 }
 
+variable "force_rollout" {
+  description = "UUID to force a rollout"
+  type        = string
+  default     = "00000000-0000-0000-0000-000000000001"
+}
+
+variable "request_rollout" {
+  description = "UUID to request a rollout"
+  type        = string
+  default     = "00000000-0000-0000-0000-000000000001"
+}
+
 variable "k8s_apiserver_authorized_networks" {
   description = "List of authorized IP ranges that can reach the AKS API server. Required (no default) so that an enterprise deployment makes an explicit choice instead of inheriting an open default. Pass ['0.0.0.0/0'] to allow all (lab use); production should pin a tight allowlist (e.g., ['203.0.113.0/24'])."
   type        = list(string)

--- a/azure/examples/simple/main.tf
+++ b/azure/examples/simple/main.tf
@@ -393,6 +393,10 @@ module "materialize_instance" {
   persist_backend_url     = local.persist_backend_url
   enable_network_policies = true
 
+  # Rollout configuration
+  force_rollout   = var.force_rollout
+  request_rollout = var.request_rollout
+
   # The password for the external login to the Materialize instance
   authenticator_kind                = "Password"
   external_login_password_mz_system = random_password.external_login_password_mz_system.result

--- a/azure/examples/simple/variables.tf
+++ b/azure/examples/simple/variables.tf
@@ -44,6 +44,18 @@ variable "license_key" {
   sensitive   = true
 }
 
+variable "force_rollout" {
+  description = "UUID to force a rollout"
+  type        = string
+  default     = "00000000-0000-0000-0000-000000000001"
+}
+
+variable "request_rollout" {
+  description = "UUID to request a rollout"
+  type        = string
+  default     = "00000000-0000-0000-0000-000000000001"
+}
+
 variable "k8s_apiserver_authorized_networks" {
   description = "List of authorized IP ranges that can access the Kubernetes API server when public access is available. Defaults to ['0.0.0.0/0'] (allow all). For production, restrict to specific IPs (e.g., ['203.0.113.0/24'])"
   type        = list(string)

--- a/gcp/examples/enterprise/main.tf
+++ b/gcp/examples/enterprise/main.tf
@@ -434,6 +434,10 @@ module "materialize_instance" {
   persist_backend_url     = local.persist_backend_url
   enable_network_policies = true
 
+  # Rollout configuration
+  force_rollout   = var.force_rollout
+  request_rollout = var.request_rollout
+
   # Use OIDC authentication via Ory Hydra. The external_login_password is still required
   # as a fallback for the mz_system admin user.
   external_login_password_mz_system = random_password.external_login_password_mz_system.result

--- a/gcp/examples/enterprise/variables.tf
+++ b/gcp/examples/enterprise/variables.tf
@@ -26,6 +26,18 @@ variable "license_key" {
   sensitive   = true
 }
 
+variable "force_rollout" {
+  description = "UUID to force a rollout"
+  type        = string
+  default     = "00000000-0000-0000-0000-000000000001"
+}
+
+variable "request_rollout" {
+  description = "UUID to request a rollout"
+  type        = string
+  default     = "00000000-0000-0000-0000-000000000001"
+}
+
 variable "ingress_cidr_blocks" {
   description = "The CIDR blocks that are allowed to reach the Load Balancer."
   type        = list(string)

--- a/gcp/examples/migration/main.tf
+++ b/gcp/examples/migration/main.tf
@@ -573,6 +573,10 @@ module "materialize_instance" {
 
   environmentd_version = var.environmentd_version
 
+  # Rollout configuration
+  force_rollout   = var.force_rollout
+  request_rollout = var.request_rollout
+
   service_account_annotations = {
     "iam.gke.io/gcp-service-account" = google_service_account.workload_identity_sa.email
   }

--- a/gcp/examples/migration/variables.tf
+++ b/gcp/examples/migration/variables.tf
@@ -195,6 +195,18 @@ variable "environmentd_version" {
   default     = null
 }
 
+variable "force_rollout" {
+  description = "UUID to force a rollout"
+  type        = string
+  default     = "00000000-0000-0000-0000-000000000001"
+}
+
+variable "request_rollout" {
+  description = "UUID to request a rollout"
+  type        = string
+  default     = "00000000-0000-0000-0000-000000000001"
+}
+
 variable "authenticator_kind" {
   description = "Kind of authenticator to use for Materialize instance."
   type        = string

--- a/gcp/examples/simple/main.tf
+++ b/gcp/examples/simple/main.tf
@@ -393,6 +393,10 @@ module "materialize_instance" {
   persist_backend_url     = local.persist_backend_url
   enable_network_policies = true
 
+  # Rollout configuration
+  force_rollout   = var.force_rollout
+  request_rollout = var.request_rollout
+
   # The password for the external login to the Materialize instance
   external_login_password_mz_system = random_password.external_login_password_mz_system.result
   authenticator_kind                = "Password"

--- a/gcp/examples/simple/variables.tf
+++ b/gcp/examples/simple/variables.tf
@@ -27,6 +27,18 @@ variable "license_key" {
   sensitive   = true
 }
 
+variable "force_rollout" {
+  description = "UUID to force a rollout"
+  type        = string
+  default     = "00000000-0000-0000-0000-000000000001"
+}
+
+variable "request_rollout" {
+  description = "UUID to request a rollout"
+  type        = string
+  default     = "00000000-0000-0000-0000-000000000001"
+}
+
 variable "ingress_cidr_blocks" {
   description = "The CIDR blocks that are allowed to reach the Load Balancer."
   type        = list(string)


### PR DESCRIPTION
Pass request_rollout and force_rollout for all clouds.

This was initially omitted for GCP and Azure, and for the GCP legacy terraform migration. Previously, they would deploy fine initially, but users would need to add these vars themselves in order to upgrade.