### PR TITLE
Parameterize GKE datapath provider (DEP-168)

### DIFF
--- a/gcp/examples/enterprise/main.tf
+++ b/gcp/examples/enterprise/main.tf
@@ -209,6 +209,7 @@ module "gke" {
   namespace                         = local.materialize_operator_namespace
   k8s_apiserver_authorized_networks = var.k8s_apiserver_authorized_networks
   labels                            = var.labels
+  datapath_provider                 = var.datapath_provider
 }
 
 # Create and configure generic node pool for all workloads except Materialize

--- a/gcp/examples/enterprise/variables.tf
+++ b/gcp/examples/enterprise/variables.tf
@@ -190,3 +190,15 @@ variable "upstream_oidc_providers" {
   nullable  = false
   sensitive = true
 }
+
+variable "datapath_provider" {
+  description = "The datapath provider (CNI) for the GKE cluster. ADVANCED_DATAPATH is GKE Dataplane V2 (eBPF-based, enforces Kubernetes NetworkPolicy natively). DATAPATH_PROVIDER_UNSPECIFIED and LEGACY_DATAPATH use the legacy GKE CNI, which silently ignores NetworkPolicy resources. GKE cannot change the datapath provider on an existing cluster: changing this forces the cluster to be rebuilt."
+  type        = string
+  default     = "ADVANCED_DATAPATH"
+  nullable    = false
+
+  validation {
+    condition     = contains(["ADVANCED_DATAPATH", "LEGACY_DATAPATH", "DATAPATH_PROVIDER_UNSPECIFIED"], var.datapath_provider)
+    error_message = "Datapath provider must be one of ADVANCED_DATAPATH, LEGACY_DATAPATH, or DATAPATH_PROVIDER_UNSPECIFIED"
+  }
+}

--- a/gcp/examples/simple/main.tf
+++ b/gcp/examples/simple/main.tf
@@ -182,6 +182,7 @@ module "gke" {
   namespace                         = local.materialize_operator_namespace
   k8s_apiserver_authorized_networks = var.k8s_apiserver_authorized_networks
   labels                            = var.labels
+  datapath_provider                 = var.datapath_provider
 
   # Pinned to STABLE: REGULAR's 1.35.x line regressed cleanup of the per-cluster
   # k8s-<cluster-uid>-node-http-hc firewall on cluster destroy, leaving the VPC

--- a/gcp/examples/simple/variables.tf
+++ b/gcp/examples/simple/variables.tf
@@ -96,3 +96,15 @@ variable "enable_observability" {
   type        = bool
   default     = false
 }
+
+variable "datapath_provider" {
+  description = "The datapath provider (CNI) for the GKE cluster. ADVANCED_DATAPATH is GKE Dataplane V2 (eBPF-based, enforces Kubernetes NetworkPolicy natively). DATAPATH_PROVIDER_UNSPECIFIED and LEGACY_DATAPATH use the legacy GKE CNI, which silently ignores NetworkPolicy resources. GKE cannot change the datapath provider on an existing cluster: changing this forces the cluster to be rebuilt."
+  type        = string
+  default     = "ADVANCED_DATAPATH"
+  nullable    = false
+
+  validation {
+    condition     = contains(["ADVANCED_DATAPATH", "LEGACY_DATAPATH", "DATAPATH_PROVIDER_UNSPECIFIED"], var.datapath_provider)
+    error_message = "Datapath provider must be one of ADVANCED_DATAPATH, LEGACY_DATAPATH, or DATAPATH_PROVIDER_UNSPECIFIED"
+  }
+}

--- a/gcp/modules/gke/README.md
+++ b/gcp/modules/gke/README.md
@@ -30,6 +30,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_secondary_range_name"></a> [cluster\_secondary\_range\_name](#input\_cluster\_secondary\_range\_name) | The name of the secondary range to use for pods | `string` | `"pods"` | no |
+| <a name="input_datapath_provider"></a> [datapath\_provider](#input\_datapath\_provider) | The datapath provider (CNI) for the GKE cluster. ADVANCED\_DATAPATH is GKE Dataplane V2 (eBPF-based, enforces Kubernetes NetworkPolicy natively). DATAPATH\_PROVIDER\_UNSPECIFIED and LEGACY\_DATAPATH use the legacy GKE CNI, which silently ignores NetworkPolicy resources. GKE cannot change the datapath provider on an existing cluster: changing this forces the cluster to be rebuilt. | `string` | `"ADVANCED_DATAPATH"` | no |
 | <a name="input_gce_persistent_disk_csi_driver_enabled"></a> [gce\_persistent\_disk\_csi\_driver\_enabled](#input\_gce\_persistent\_disk\_csi\_driver\_enabled) | Whether to enable the GCE persistent disk CSI driver | `bool` | `true` | no |
 | <a name="input_horizontal_pod_autoscaling_disabled"></a> [horizontal\_pod\_autoscaling\_disabled](#input\_horizontal\_pod\_autoscaling\_disabled) | Whether to disable horizontal pod autoscaling | `bool` | `false` | no |
 | <a name="input_http_load_balancing_disabled"></a> [http\_load\_balancing\_disabled](#input\_http\_load\_balancing\_disabled) | Whether to disable HTTP load balancing | `bool` | `false` | no |

--- a/gcp/modules/gke/main.tf
+++ b/gcp/modules/gke/main.tf
@@ -45,10 +45,12 @@ resource "google_container_cluster" "primary" {
   network         = var.network_name
   subnetwork      = var.subnet_name
 
-  # Dataplane V2 uses eBPF-based networking with built-in NetworkPolicy support
-  # Standard Kubernetes NetworkPolicy is automatically enforced
+  # ADVANCED_DATAPATH (Dataplane V2) uses eBPF-based networking with built-in
+  # NetworkPolicy support; standard Kubernetes NetworkPolicy is automatically
+  # enforced. The legacy datapath ignores NetworkPolicy resources entirely.
+  # Cannot be changed on an existing cluster without rebuilding it.
   # Reference: https://cloud.google.com/kubernetes-engine/docs/how-to/dataplane-v2
-  datapath_provider = "ADVANCED_DATAPATH"
+  datapath_provider = var.datapath_provider
 
   remove_default_node_pool = true
   initial_node_count       = 1

--- a/gcp/modules/gke/variables.tf
+++ b/gcp/modules/gke/variables.tf
@@ -46,6 +46,17 @@ variable "networking_mode" {
   }
 }
 
+variable "datapath_provider" {
+  description = "The datapath provider (CNI) for the GKE cluster. ADVANCED_DATAPATH is GKE Dataplane V2 (eBPF-based, enforces Kubernetes NetworkPolicy natively). DATAPATH_PROVIDER_UNSPECIFIED and LEGACY_DATAPATH use the legacy GKE CNI, which silently ignores NetworkPolicy resources. GKE cannot change the datapath provider on an existing cluster: changing this forces the cluster to be rebuilt."
+  type        = string
+  default     = "ADVANCED_DATAPATH"
+  nullable    = false
+  validation {
+    condition     = contains(["ADVANCED_DATAPATH", "LEGACY_DATAPATH", "DATAPATH_PROVIDER_UNSPECIFIED"], var.datapath_provider)
+    error_message = "Datapath provider must be one of ADVANCED_DATAPATH, LEGACY_DATAPATH, or DATAPATH_PROVIDER_UNSPECIFIED"
+  }
+}
+
 variable "cluster_secondary_range_name" {
   description = "The name of the secondary range to use for pods"
   type        = string


### PR DESCRIPTION
## Summary

The `gcp/modules/gke` module hardcoded `datapath_provider = "ADVANCED_DATAPATH"` (Dataplane V2 / eBPF CNI). GKE cannot change the datapath provider on an existing cluster, so clusters built with the legacy CNI (everything created by the old terraform module) could not adopt this module without a full cluster rebuild.

- Add a `datapath_provider` variable to `gcp/modules/gke`, defaulting to `ADVANCED_DATAPATH` (no behavior change for current users). Accepts `ADVANCED_DATAPATH`, `LEGACY_DATAPATH`, and `DATAPATH_PROVIDER_UNSPECIFIED`.
- Expose the variable in the `simple` and `enterprise` GCP examples and pass it through to the gke module.
- Document that the legacy CNI silently ignores `NetworkPolicy` resources, and that changing the value forces cluster replacement.

Per discussion on the issue, this only parameterizes the CNI; network policy resources are still created by default (they are simply not enforced on the legacy datapath).

Refs [DEP-168](https://linear.app/materializeinc/issue/DEP-168/parameterize-gke-cni-and-make-network-policies-optional)

## Testing

Manually running the rust tests, once with the defaults and once with an overridden datapath_provider to use the legacy datapath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)