### PR TITLE
Use libpq-compatible sslmode in the Polis DSN across the enterprise examples

### DIFF
--- a/aws/examples/enterprise/main.tf
+++ b/aws/examples/enterprise/main.tf
@@ -738,8 +738,9 @@ locals {
     "hydra"
   )
 
+  # uselibpqcompat=true keeps sslmode=require at libpq semantics (encrypt, don't verify).
   ory_polis_dsn = var.enable_polis ? format(
-    "postgres://%s:%s@%s/%s?sslmode=require",
+    "postgres://%s:%s@%s/%s?sslmode=require&uselibpqcompat=true",
     module.ory_polis_database[0].db_instance_username,
     urlencode(random_password.ory_database_password.result),
     module.ory_polis_database[0].db_instance_endpoint,

--- a/azure/examples/enterprise/main.tf
+++ b/azure/examples/enterprise/main.tf
@@ -157,8 +157,9 @@ locals {
     "hydra"
   )
 
+  # uselibpqcompat=true keeps sslmode=require at libpq semantics (encrypt, don't verify).
   ory_polis_dsn = format(
-    "postgres://%s:%s@%s/%s?sslmode=require",
+    "postgres://%s:%s@%s/%s?sslmode=require&uselibpqcompat=true",
     module.ory_database.administrator_login,
     urlencode(module.ory_database.administrator_password),
     module.ory_database.server_fqdn,

--- a/gcp/examples/enterprise/main.tf
+++ b/gcp/examples/enterprise/main.tf
@@ -166,8 +166,9 @@ locals {
     "hydra"
   )
 
+  # uselibpqcompat=true keeps sslmode=require at libpq semantics (encrypt, don't verify).
   ory_polis_dsn = format(
-    "postgres://%s:%s@%s/%s?sslmode=require",
+    "postgres://%s:%s@%s/%s?sslmode=require&uselibpqcompat=true",
     module.ory_database.users[0].name,
     urlencode(module.ory_database.users[0].password),
     module.ory_database.private_ip,


### PR DESCRIPTION
Node's pg client treats sslmode=require as verify-full and rejects the self-signed cert Cloud SQL presents, so the Polis migration Job fails on GCP; appending uselibpqcompat=true reverts to libpq semantics (encrypt, don't verify) and matches how the Go-based Kratos/Hydra clients already connect. Linear: DEP-145 (Polis follow-up).