### PR TITLE
Add release workflow with auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+    - title: Documentation 📚
+      labels:
+        - documentation
+    - title: Dependencies ⬆️
+      labels:
+        - dependencies
+        - github_actions
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,21 @@ Pull requests are the best way to propose changes to the codebase. We actively w
 5. Make sure your code lints.
 6. Issue that pull request!
 
+### PR Labels
+
+We use labels to categorize pull requests in auto-generated release notes (see [.github/release.yml](./.github/release.yml)). Please apply the label that best describes your change:
+
+| Label | Release notes section |
+|-------|----------------------|
+| `breaking-change` | Breaking Changes 🛠 |
+| `enhancement` | New Features 🎉 |
+| `bug` | Bug Fixes 🐛 |
+| `documentation` | Documentation 📚 |
+| `dependencies`, `github_actions` | Dependencies ⬆️ |
+| `ignore-for-release` | Excluded from release notes |
+
+Unlabeled PRs land under "Other Changes".
+
 
 ## Generating Documentation
 
@@ -96,6 +111,8 @@ Perform a manual test of the latest code on `main`. See prior section. Then run:
 
     git tag -a vX.Y.Z -m vX.Y.Z
     git push origin vX.Y.Z
+
+Pushing the tag triggers the [release workflow](./.github/workflows/release.yml), which creates a GitHub release with auto-generated release notes. Notes are grouped by PR label per [.github/release.yml](./.github/release.yml), so make sure merged PRs are labeled correctly (see [PR Labels](#pr-labels)) before tagging.
 
 ## References
 


### PR DESCRIPTION
## Summary
- New `release.yml` workflow: pushing a `vX.Y.Z` tag creates a GitHub release with auto-generated notes (`gh release create --generate-notes`, built-in `GITHUB_TOKEN`, no third-party actions)
- New `.github/release.yml` config: groups release notes by PR label (Breaking Changes, New Features, Bug Fixes, Documentation, Dependencies, Other Changes); excludes dependabot and `ignore-for-release` PRs
- CONTRIBUTING.md: documents PR labels and the updated release process

Also created two new repo labels: `breaking-change` and `ignore-for-release`.

## Test plan
- [ ] After merge, push a test tag (e.g. next patch release) and confirm the workflow creates a release with grouped notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)