### PR TITLE
Stop renovate from dropping provider version floors

### DIFF
--- a/aws/modules/aws-lbc/README.md
+++ b/aws/modules/aws-lbc/README.md
@@ -6,7 +6,7 @@
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0, < 3.10.0 |
 
 ## Providers
 

--- a/aws/modules/aws-lbc/versions.tf
+++ b/aws/modules/aws-lbc/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = "~> 3.0, < 3.10.0"
     }
   }
 }

--- a/aws/modules/karpenter-ec2nodeclass/README.md
+++ b/aws/modules/karpenter-ec2nodeclass/README.md
@@ -4,11 +4,11 @@
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
-| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | < 1.4.0 |
+| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 2.4.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0, < 3.10.0 |
 
 ## Providers
 

--- a/aws/modules/karpenter-ec2nodeclass/versions.tf
+++ b/aws/modules/karpenter-ec2nodeclass/versions.tf
@@ -16,11 +16,11 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = "~> 3.0, < 3.10.0"
     }
     deepmerge = {
       source  = "isometry/deepmerge"
-      version = "< 1.4.0"
+      version = "~> 1.0, < 1.4.0"
     }
     kubectl = {
       source  = "alekc/kubectl"

--- a/aws/modules/karpenter-nodepool/README.md
+++ b/aws/modules/karpenter-nodepool/README.md
@@ -4,11 +4,11 @@
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
-| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | < 1.4.0 |
+| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 2.4.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0, < 3.10.0 |
 
 ## Providers
 

--- a/aws/modules/karpenter-nodepool/versions.tf
+++ b/aws/modules/karpenter-nodepool/versions.tf
@@ -16,11 +16,11 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = "~> 3.0, < 3.10.0"
     }
     deepmerge = {
       source  = "isometry/deepmerge"
-      version = "< 1.4.0"
+      version = "~> 1.0, < 1.4.0"
     }
     kubectl = {
       source  = "alekc/kubectl"

--- a/aws/modules/karpenter/README.md
+++ b/aws/modules/karpenter/README.md
@@ -4,11 +4,11 @@
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
-| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | < 1.4.0 |
+| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 2.4.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0, < 3.10.0 |
 
 ## Providers
 

--- a/aws/modules/karpenter/versions.tf
+++ b/aws/modules/karpenter/versions.tf
@@ -16,11 +16,11 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = "~> 3.0, < 3.10.0"
     }
     deepmerge = {
       source  = "isometry/deepmerge"
-      version = "< 1.4.0"
+      version = "~> 1.0, < 1.4.0"
     }
     kubectl = {
       source  = "alekc/kubectl"

--- a/aws/modules/nlb/README.md
+++ b/aws/modules/nlb/README.md
@@ -7,7 +7,7 @@
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 2.4.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0, < 3.10.0 |
 
 ## Providers
 

--- a/aws/modules/nlb/target/README.md
+++ b/aws/modules/nlb/target/README.md
@@ -7,7 +7,7 @@
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 2.4.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0, < 3.10.0 |
 
 ## Providers
 

--- a/aws/modules/nlb/target/versions.tf
+++ b/aws/modules/nlb/target/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = "~> 3.0, < 3.10.0"
     }
     kubectl = {
       source  = "alekc/kubectl"

--- a/aws/modules/nlb/versions.tf
+++ b/aws/modules/nlb/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = "~> 3.0, < 3.10.0"
     }
     kubectl = {
       source  = "alekc/kubectl"

--- a/aws/modules/operator/README.md
+++ b/aws/modules/operator/README.md
@@ -4,7 +4,7 @@
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
-| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | < 1.4.0 |
+| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
 

--- a/aws/modules/operator/versions.tf
+++ b/aws/modules/operator/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     deepmerge = {
       source  = "isometry/deepmerge"
-      version = "< 1.4.0"
+      version = "~> 1.0, < 1.4.0"
     }
   }
 }

--- a/aws/modules/storage/README.md
+++ b/aws/modules/storage/README.md
@@ -4,14 +4,14 @@
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0, < 3.10.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0, < 5.101.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | < 3.10.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0, < 3.10.0 |
 
 ## Modules
 

--- a/aws/modules/storage/versions.tf
+++ b/aws/modules/storage/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = "~> 3.0, < 3.10.0"
     }
   }
 }

--- a/azure/modules/aks/README.md
+++ b/azure/modules/aks/README.md
@@ -4,7 +4,7 @@
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0, < 4.76.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5, < 3.10.0 |
 
 ## Providers
 

--- a/azure/modules/aks/versions.tf
+++ b/azure/modules/aks/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = "~> 3.5, < 3.10.0"
     }
   }
 }

--- a/azure/modules/database/README.md
+++ b/azure/modules/database/README.md
@@ -4,14 +4,14 @@
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.75.0, < 4.76.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0, < 3.10.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.75.0, < 4.76.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | < 3.10.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0, < 3.10.0 |
 
 ## Modules
 

--- a/azure/modules/database/versions.tf
+++ b/azure/modules/database/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = "~> 3.0, < 3.10.0"
     }
   }
 }

--- a/azure/modules/load_balancers/README.md
+++ b/azure/modules/load_balancers/README.md
@@ -3,7 +3,7 @@
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | < 3.10.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 2.45.0, < 3.10.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.75.0, < 4.76.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |

--- a/azure/modules/load_balancers/versions.tf
+++ b/azure/modules/load_balancers/versions.tf
@@ -10,7 +10,7 @@ terraform {
 
     azuread = {
       source  = "hashicorp/azuread"
-      version = "< 3.10.0"
+      version = ">= 2.45.0, < 3.10.0"
     }
 
     kubernetes = {

--- a/azure/modules/networking/README.md
+++ b/azure/modules/networking/README.md
@@ -4,14 +4,14 @@
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0, < 4.76.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5, < 3.10.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0, < 4.76.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | < 3.10.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5, < 3.10.0 |
 
 ## Modules
 

--- a/azure/modules/networking/versions.tf
+++ b/azure/modules/networking/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = "~> 3.5, < 3.10.0"
     }
   }
 }

--- a/azure/modules/operator/README.md
+++ b/azure/modules/operator/README.md
@@ -3,7 +3,7 @@
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
-| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | < 1.4.0 |
+| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
 

--- a/azure/modules/operator/versions.tf
+++ b/azure/modules/operator/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     deepmerge = {
       source  = "isometry/deepmerge"
-      version = "< 1.4.0"
+      version = "~> 1.0, < 1.4.0"
     }
   }
 }

--- a/azure/modules/storage/README.md
+++ b/azure/modules/storage/README.md
@@ -4,15 +4,15 @@
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.75.0, < 4.76.0 |
-| <a name="requirement_external"></a> [external](#requirement\_external) | < 2.5.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.3.4, < 2.5.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.0, < 3.10.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.75.0, < 4.76.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | < 3.10.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.0, < 3.10.0 |
 
 ## Modules
 

--- a/azure/modules/storage/versions.tf
+++ b/azure/modules/storage/versions.tf
@@ -8,11 +8,11 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = ">= 3.5.0, < 3.10.0"
     }
     external = {
       source  = "hashicorp/external"
-      version = "< 2.5.0"
+      version = ">= 2.3.4, < 2.5.0"
 
     }
   }

--- a/gcp/modules/operator/README.md
+++ b/gcp/modules/operator/README.md
@@ -3,7 +3,7 @@
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
-| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | < 1.4.0 |
+| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
 

--- a/gcp/modules/operator/versions.tf
+++ b/gcp/modules/operator/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     deepmerge = {
       source  = "isometry/deepmerge"
-      version = "< 1.4.0"
+      version = "~> 1.0, < 1.4.0"
     }
   }
 }

--- a/kubernetes/modules/cert-manager/README.md
+++ b/kubernetes/modules/cert-manager/README.md
@@ -5,7 +5,7 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.5.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0, < 2.39.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1, < 3.10.0 |
 
 ## Providers
 

--- a/kubernetes/modules/cert-manager/versions.tf
+++ b/kubernetes/modules/cert-manager/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = "~> 3.1, < 3.10.0"
     }
   }
 }

--- a/kubernetes/modules/coredns/README.md
+++ b/kubernetes/modules/coredns/README.md
@@ -4,7 +4,7 @@
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | < 3.4.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0, < 3.4.0 |
 
 ## Providers
 

--- a/kubernetes/modules/coredns/versions.tf
+++ b/kubernetes/modules/coredns/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     null = {
       source  = "hashicorp/null"
-      version = "< 3.4.0"
+      version = "~> 3.0, < 3.4.0"
     }
   }
 }

--- a/kubernetes/modules/grafana/README.md
+++ b/kubernetes/modules/grafana/README.md
@@ -5,7 +5,7 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.5.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0, < 2.39.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0, < 3.10.0 |
 
 ## Providers
 
@@ -13,7 +13,7 @@
 | ---- | ------- |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.5.0, < 2.18.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10.0, < 2.39.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | < 3.10.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0, < 3.10.0 |
 
 ## Modules
 

--- a/kubernetes/modules/grafana/versions.tf
+++ b/kubernetes/modules/grafana/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = ">= 3.0.0, < 3.10.0"
     }
   }
 }

--- a/kubernetes/modules/ory-hydra/README.md
+++ b/kubernetes/modules/ory-hydra/README.md
@@ -12,10 +12,10 @@ keys: https://github.com/ory/k8s/blob/master/helm/charts/hydra/values.yaml
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
-| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | < 1.4.0 |
+| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0, < 3.10.0 |
 
 ## Providers
 
@@ -23,7 +23,7 @@ keys: https://github.com/ory/k8s/blob/master/helm/charts/hydra/values.yaml
 | ---- | ------- |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0, < 2.39.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | < 3.10.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0, < 3.10.0 |
 
 ## Modules
 

--- a/kubernetes/modules/ory-hydra/versions.tf
+++ b/kubernetes/modules/ory-hydra/versions.tf
@@ -12,11 +12,11 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = ">= 3.0.0, < 3.10.0"
     }
     deepmerge = {
       source  = "isometry/deepmerge"
-      version = "< 1.4.0"
+      version = "~> 1.0, < 1.4.0"
     }
   }
 }

--- a/kubernetes/modules/ory-kratos/README.md
+++ b/kubernetes/modules/ory-kratos/README.md
@@ -12,10 +12,10 @@ keys: https://github.com/ory/k8s/blob/master/helm/charts/kratos/values.yaml
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
-| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | < 1.4.0 |
+| <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0, < 3.10.0 |
 
 ## Providers
 
@@ -23,7 +23,7 @@ keys: https://github.com/ory/k8s/blob/master/helm/charts/kratos/values.yaml
 | ---- | ------- |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0, < 2.39.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | < 3.10.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0, < 3.10.0 |
 
 ## Modules
 

--- a/kubernetes/modules/ory-kratos/versions.tf
+++ b/kubernetes/modules/ory-kratos/versions.tf
@@ -12,11 +12,11 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = ">= 3.0.0, < 3.10.0"
     }
     deepmerge = {
       source  = "isometry/deepmerge"
-      version = "< 1.4.0"
+      version = "~> 1.0, < 1.4.0"
     }
   }
 }

--- a/kubernetes/modules/ory-selfservice-ui/README.md
+++ b/kubernetes/modules/ory-selfservice-ui/README.md
@@ -4,14 +4,14 @@
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0, < 3.10.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0, < 2.39.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | < 3.10.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0, < 3.10.0 |
 
 ## Modules
 

--- a/kubernetes/modules/ory-selfservice-ui/versions.tf
+++ b/kubernetes/modules/ory-selfservice-ui/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = ">= 3.0.0, < 3.10.0"
     }
   }
 }

--- a/kubernetes/modules/self-signed-cluster-issuer/README.md
+++ b/kubernetes/modules/self-signed-cluster-issuer/README.md
@@ -6,7 +6,7 @@
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.5.0, < 2.18.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 2.4.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0, < 2.39.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | < 3.10.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1, < 3.10.0 |
 
 ## Providers
 

--- a/kubernetes/modules/self-signed-cluster-issuer/versions.tf
+++ b/kubernetes/modules/self-signed-cluster-issuer/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "< 3.10.0"
+      version = "~> 3.1, < 3.10.0"
     }
     kubectl = {
       source  = "alekc/kubectl"

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "rangeStrategy": "widen",
+  "postUpgradeTasks": {
+    "commands": ["bash .github/scripts/generate-docs.sh"],
+    "fileFilters": ["**/README.md"],
+    "executionMode": "branch"
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,5 @@
   "extends": [
     "config:recommended"
   ],
-  "rangeStrategy": "widen",
-  "postUpgradeTasks": {
-    "commands": ["bash .github/scripts/generate-docs.sh"],
-    "fileFilters": ["**/README.md"],
-    "executionMode": "branch"
-  }
+  "rangeStrategy": "widen"
 }


### PR DESCRIPTION
Renovate's default replace strategy was collapsing compound constraints like `~> 3.0, < 3.3.0` down to just the upper bound (`< 3.4.0`), dropping the lower bound and allowing downgrades. This sets `rangeStrategy: widen` so future bumps keep the floor and only move the upper bound, and restores the floors that already got dropped across random, deepmerge, external, null, and azuread.

Verified with a renovate local dry-run: with the current config a `~> 3.0, < 3.5.0` constraint becomes `< 3.9.1` (floor dropped), while with `rangeStrategy: widen` it becomes `~> 3.0, < 3.9.1` (floor kept).

Docs regeneration will move to CI in a follow-up, since post-upgrade commands can't be allowlisted on our renovate offering.