### PR TITLE
Auto-regenerate module docs on renovate PRs

### DIFF
--- a/.github/workflows/renovate-docs.yml
+++ b/.github/workflows/renovate-docs.yml
@@ -1,0 +1,50 @@
+name: Renovate Docs
+
+# Regenerates module docs on renovate PRs and commits them back to the branch,
+# so dependency bumps do not fail the "Check Generated Docs" lint job.
+#
+# The push must use a token other than the default GITHUB_TOKEN, otherwise the
+# resulting commit will not re-trigger the required checks. Provide a fine-grained
+# PAT (or GitHub App token) with contents:write as the RENOVATE_DOCS_TOKEN secret.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.tf"
+
+permissions:
+  contents: write
+
+jobs:
+  regenerate-docs:
+    name: Regenerate Docs
+    if: startsWith(github.head_ref, 'renovate/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.RENOVATE_DOCS_TOKEN }}
+
+      - name: Setup terraform-docs
+        uses: jaxxstorm/action-install-gh-release@25e24d2d23ae098373794ef1d6faecb48ee52da8 # v3.0.0
+        with:
+          repo: terraform-docs/terraform-docs
+          tag: v0.24.0
+
+      - name: Generate docs
+        run: .github/scripts/generate-docs.sh
+
+      - name: Commit regenerated docs
+        run: |
+          if git diff --quiet; then
+            echo "Docs already up to date."
+            exit 0
+          fi
+          git config user.name "renovate[bot]"
+          git config user.email "29139614+renovate[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Regenerate module docs"
+          git push


### PR DESCRIPTION
Adds a CI job that regenerates the module docs on renovate PRs and commits them back to the branch, so dependency bumps stop failing the Check Generated Docs lint job. This replaces the postUpgradeTasks approach from #290, which our renovate offering can't run since it only allows a small fixed set of post-upgrade commands.

It triggers on renovate/* PRs that touch .tf files, runs generate-docs.sh with the same terraform-docs v0.24.0 the lint job uses, and pushes a commit only when docs actually changed.

One setup step before it works end to end: it needs a RENOVATE_DOCS_TOKEN secret (a fine-grained PAT or GitHub App token with contents:write). The default GITHUB_TOKEN can't be used, since commits it pushes don't re-trigger the required checks, so the regenerated commit would never flip the docs check green. Please don't mark this job as a required check, it is path-filtered and will show as skipped on PRs that don't touch .tf.