### PR TITLE
Add CODEOWNERS for automatic reviewer selection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Include @materialize-bot in all rules.
+#
+# Doing so allows teams that don't want notifications on PRs sent to every
+# member, by adding the bot to their team and enabling the "only notify
+# requested team members" option.
+#
+# See: https://github.com/orgs/community/discussions/35673#discussioncomment-10561942
+
+* @MaterializeInc/cloud @MaterializeInc/on-call @materialize-bot


### PR DESCRIPTION
Adds a `.github/CODEOWNERS` file mirroring the ownership rules from the cloud repo: all files owned by `@MaterializeInc/cloud` and `@MaterializeInc/on-call`, with `@materialize-bot` included in the rule to support per-team notification settings.

Cloud's path-specific rules (`src/prometheus-exporter/*`, `.github/workflows/upgrade-*`) were dropped since those paths don't exist in this repo.

Once merged, GitHub will automatically request reviews from these teams on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)