### PR TITLE
fix(coredns): stop leaking kubeconfig in plan output

### DIFF
--- a/kubernetes/modules/coredns/README.md
+++ b/kubernetes/modules/coredns/README.md
@@ -30,8 +30,6 @@
 | [kubernetes_service_account.coredns](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
 | [terraform_data.scale_down_kube_dns](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.scale_down_kube_dns_autoscaler](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
-| [terraform_data.scale_up_kube_dns](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
-| [terraform_data.scale_up_kube_dns_autoscaler](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 
 ## Inputs
 

--- a/kubernetes/modules/coredns/main.tf
+++ b/kubernetes/modules/coredns/main.tf
@@ -250,20 +250,43 @@ resource "kubernetes_deployment" "coredns" {
 }
 
 
+# Scale down the default kube-dns deployment (and its autoscaler) so only
+# the custom CoreDNS serves DNS.
+#
+# The kubeconfig is passed to the provisioner via `environment` and is never
+# stored in the resource: terraform_data mirrors `input` into its
+# non-sensitive `output` attribute, which would print the kubeconfig in
+# cleartext in plan and destroy diffs.
+#
+# There is deliberately no destroy-time counterpart that scales kube-dns back
+# up. Destroy-time provisioners can only reference `self`, so the kubeconfig
+# would have to live in state, and the credentials captured there are
+# almost always expired by the time a destroy runs. An operator removing only
+# the CoreDNS module (without destroying the cluster) must scale kube-dns
+# back up manually:
+#   kubectl scale deployment <kube-dns deployment> -n kube-system --replicas=2
+#   kubectl scale deployment <kube-dns autoscaler deployment> -n kube-system --replicas=1
+#
+# Terraform 1.16 adds a `store` block to terraform_data whose value can be
+# marked sensitive (masked `sensitive_output` attribute, see
+# https://github.com/hashicorp/terraform/pull/38298). Once 1.16 is an
+# acceptable required_version floor, a destroy-time scale-up could be
+# reintroduced by storing the kubeconfig there and reading
+# `self.store.sensitive_output` — though the stored credentials would still
+# usually be expired by destroy time.
 resource "terraform_data" "scale_down_kube_dns_autoscaler" {
-  count = var.disable_default_coredns_autoscaler ? 1 : 0
-  input = {
-    KUBECONFIG_DATA = var.kubeconfig_data
-    DEPLOYMENT_NAME = var.coredns_autoscaler_deployment_to_scale_down
-    NAMESPACE       = local.namespace
-  }
+  count            = var.disable_default_coredns_autoscaler ? 1 : 0
   triggers_replace = [var.cluster_identifier, var.coredns_autoscaler_deployment_to_scale_down, local.namespace]
   provisioner "local-exec" {
     interpreter = ["/usr/bin/env", "bash", "-c"]
     when        = create
     on_failure  = fail
-    environment = self.input
-    command     = <<-EOT
+    environment = {
+      KUBECONFIG_DATA = var.kubeconfig_data
+      DEPLOYMENT_NAME = var.coredns_autoscaler_deployment_to_scale_down
+      NAMESPACE       = local.namespace
+    }
+    command = <<-EOT
       set -euo pipefail
 
       kubeconfig_file=$(mktemp)
@@ -284,18 +307,17 @@ resource "terraform_data" "scale_down_kube_dns_autoscaler" {
 }
 
 resource "terraform_data" "scale_down_kube_dns" {
-  count = var.disable_default_coredns ? 1 : 0
-  input = {
-    KUBECONFIG_DATA = var.kubeconfig_data
-    DEPLOYMENT_NAME = var.coredns_deployment_to_scale_down
-    NAMESPACE       = local.namespace
-  }
+  count            = var.disable_default_coredns ? 1 : 0
   triggers_replace = [var.cluster_identifier, var.coredns_deployment_to_scale_down, local.namespace]
   provisioner "local-exec" {
     interpreter = ["/usr/bin/env", "bash", "-c"]
     when        = create
     on_failure  = fail
-    environment = self.input
+    environment = {
+      KUBECONFIG_DATA = var.kubeconfig_data
+      DEPLOYMENT_NAME = var.coredns_deployment_to_scale_down
+      NAMESPACE       = local.namespace
+    }
 
     command = <<-EOT
       set -euo pipefail
@@ -317,83 +339,6 @@ resource "terraform_data" "scale_down_kube_dns" {
   }
 
   depends_on = [terraform_data.scale_down_kube_dns_autoscaler]
-}
-
-# Scale up the default CoreDNS during cleanup.
-# on_failure = continue: the scale-up is best-effort. If the cluster is also
-# being destroyed or the kubeconfig token has expired, failing here should not
-# block the operation. An operator removing only the CoreDNS module (without
-# destroying the cluster) should verify that kube-dns is running afterward.
-resource "terraform_data" "scale_up_kube_dns_autoscaler" {
-  count = var.disable_default_coredns_autoscaler ? 1 : 0
-  input = {
-    KUBECONFIG_DATA = var.kubeconfig_data
-    DEPLOYMENT_NAME = var.coredns_autoscaler_deployment_to_scale_down
-    NAMESPACE       = local.namespace
-  }
-  triggers_replace = [var.cluster_identifier, var.coredns_autoscaler_deployment_to_scale_down, local.namespace]
-  provisioner "local-exec" {
-    interpreter = ["/usr/bin/env", "bash", "-c"]
-    when        = destroy
-    on_failure  = continue
-    environment = self.input
-    command     = <<-EOT
-      set -euo pipefail
-
-      kubeconfig_file=$(mktemp)
-      trap "rm -f '$${kubeconfig_file}'" EXIT
-      echo "$${KUBECONFIG_DATA}" > "$${kubeconfig_file}"
-
-      output=$(kubectl --kubeconfig="$${kubeconfig_file}" scale deployment $${DEPLOYMENT_NAME} -n $${NAMESPACE} --replicas=1 2>&1) || {
-        if echo "$output" | grep -q "no objects passed to scale"; then
-          echo "Deployment $${DEPLOYMENT_NAME} not found, skipping"
-          exit 0
-        fi
-        echo "WARNING: Failed to scale up $${DEPLOYMENT_NAME}: $output"
-        echo "If the cluster still exists, manually run: kubectl scale deployment $${DEPLOYMENT_NAME} -n $${NAMESPACE} --replicas=1"
-        exit 1
-      }
-      echo "Successfully scaled up $${DEPLOYMENT_NAME} to 1 replica"
-    EOT
-  }
-  depends_on = [terraform_data.scale_down_kube_dns]
-}
-
-resource "terraform_data" "scale_up_kube_dns" {
-  count = var.disable_default_coredns ? 1 : 0
-
-  input = {
-    KUBECONFIG_DATA = var.kubeconfig_data
-    DEPLOYMENT_NAME = var.coredns_deployment_to_scale_down
-    NAMESPACE       = local.namespace
-  }
-  triggers_replace = [var.cluster_identifier, var.coredns_deployment_to_scale_down, local.namespace]
-  provisioner "local-exec" {
-    interpreter = ["/usr/bin/env", "bash", "-c"]
-    when        = destroy
-    on_failure  = continue
-    environment = self.input
-    command     = <<-EOT
-      set -euo pipefail
-
-      kubeconfig_file=$(mktemp)
-      trap "rm -f '$${kubeconfig_file}'" EXIT
-      echo "$${KUBECONFIG_DATA}" > "$${kubeconfig_file}"
-
-      output=$(kubectl --kubeconfig="$${kubeconfig_file}" scale deployment $${DEPLOYMENT_NAME} -n $${NAMESPACE} --replicas=2 2>&1) || {
-        if echo "$output" | grep -q "no objects passed to scale"; then
-          echo "Deployment $${DEPLOYMENT_NAME} not found, skipping"
-          exit 0
-        fi
-        echo "WARNING: Failed to scale up $${DEPLOYMENT_NAME}: $output"
-        echo "If the cluster still exists, manually run: kubectl scale deployment $${DEPLOYMENT_NAME} -n $${NAMESPACE} --replicas=2"
-        exit 1
-      }
-      echo "Successfully scaled up $${DEPLOYMENT_NAME} to 2 replicas"
-    EOT
-  }
-
-  depends_on = [terraform_data.scale_up_kube_dns_autoscaler]
 }
 
 module "hpa" {


### PR DESCRIPTION
Fixes [DEP-169](https://linear.app/materializeinc/issue/DEP-169/scale-up-kube-dns-not-treated-as-sensitive-output-in-sm-terraform).

## Problem

`terraform_data` mirrors `input` into its non-sensitive `output` attribute, so any plan that updated (e.g. on token rotation) or destroyed the kube-dns scale resources printed the full kubeconfig — including the auth token — in cleartext in CI logs. Wrapping the input in `sensitive()` does not help; upstream considers the behavior working as designed (hashicorp/terraform#32789, closed by the Terraform 1.16 `store` block, hashicorp/terraform#38298).

## Fix

- **`scale_down_kube_dns{,_autoscaler}`**: pass the kubeconfig to the create-time provisioners via `environment`, referencing `var.kubeconfig_data` directly. Nothing sensitive is stored in state, so nothing can render in a plan. `triggers_replace` semantics unchanged.
- **`scale_up_kube_dns{,_autoscaler}` removed**: destroy-time provisioners can only reference `self`, so the kubeconfig would have to live in state — and the credentials captured there are almost always expired by the time a destroy runs, so the best-effort scale-up rarely worked. Operators removing the module without destroying the cluster must scale kube-dns back up manually (documented in the module, along with the 1.16 `store` breadcrumb for reintroducing it later).

## Migration

Existing deployments update `scale_down_*` in place and destroy the old `scale_up_*` **without running their destroy provisioners** — kube-dns stays scaled down. The migration plan displays the old `output` values one final time (they are already in state and were shown in prior plans); after that, rotation produces an empty plan.

## Verification

Manually tested by upgrading from main to this branch and then running the destroy.

Additionally tested by Claude end-to-end against a kind cluster with the real module, plus a fake-kubectl harness on the exact resource definitions:

- apply scales kube-dns and its autoscaler to 0, custom CoreDNS serves
- kubeconfig rotation → `No changes.` (previously an in-place update that printed the kubeconfig)
- destroy plan/apply: zero occurrences of key material in any output (grepped for the actual client key)
- migration from `main`: no provisioner re-runs, state converges, kube-dns untouched
- `terraform validate`, `tflint`, `terraform fmt -check` pass

## Follow-ups (separate tickets)

The same `input` leak pattern exists in `aws/modules/karpenter-nodepool` (`destroyer`, destroy-time — needs the same drop-or-rework decision) and `aws/modules/vpc-cni` (`annotate_existing_resources`, create-time — trivially fixable like this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)