### PR TITLE
fix(aws): make nodepool terminationGracePeriod configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,39 @@ We follow semantic versioning with our tags. If a particular version requires ad
 
 ### Upgrade Notes
 
+#### v6.0.0
+
+The AWS `karpenter-nodepool` module no longer hardcodes `terminationGracePeriod: 300s` on Karpenter NodePools. A new `termination_grace_period` variable controls it and defaults to `null` (unset).
+
+With a `terminationGracePeriod` set, Karpenter replaces drifted nodes (for example, after changing the node pool's instance types) even when pods carry the `karpenter.sh/do-not-disrupt` annotation — the annotation and PDBs only delay eviction until the node's termination deadline. Materialize instance pods were therefore force-evicted about 5 minutes after any node pool change. With it unset, do-not-disrupt pods block disruption until a Materialize rollout moves them.
+
+The AWS examples now set `termination_grace_period = "300s"` on the generic pool (matching the previously hardcoded value; its workloads tolerate eviction) and leave it unset on the materialize pool.
+
+**Impact on existing deployments:**
+
+Karpenter stamps `terminationGracePeriod` into each NodeClaim when the node is created and never updates it afterwards; changing the NodePool only marks existing nodes as Drifted. Existing materialize nodes were created with `300s` baked in, so the first `terraform apply` that changes the NodePool template (including removing `terminationGracePeriod`) drift-replaces them, and their baked-in deadline bypasses do-not-disrupt one final time. Materialize pods restart with a short interruption.
+
+If a one-time restart of your Materialize instances is acceptable, bump `ref=<tag>` and apply. The replacement nodes are created without `terminationGracePeriod`, and node pool changes from then on respect do-not-disrupt.
+
+To migrate without downtime, keep the old pool's template unchanged and move pods to a new pool first, similar to the GCP node pool migration in v5.0.0:
+
+1. Bump `ref=<tag>` on all modules, and set `termination_grace_period = "300s"` on your existing materialize nodepool module instance. This matches the value the module previously hardcoded, so the NodePool template is unchanged and no nodes drift. Keep the generic pool at `"300s"` (as the examples do) and its nodes don't drift either.
+2. `terraform apply`. There should be no changes to the `termination_grace_period` on the node pools.
+3. Add a second materialize nodepool module instance with a new `name` (for example `materialize2`), the same `nodeclass_name`, labels, and taints, but `termination_grace_period` should be unset.
+4. `terraform init && terraform apply` to create the new NodePool. It has no nodes yet.
+5. Prevent the old NodePool from provisioning new nodes by setting `limits = { cpu = "0" }` on the old materialize nodepool module instance. Limits are not part of the NodePool template, so this does not drift the existing nodes.
+6. `terraform apply` to cap the old NodePool. Do this before cordoning: if the pool were still uncapped when its nodes are cordoned, any pending pods could cause Karpenter to provision fresh (uncordoned) nodes from the old pool.
+7. Cordon the old pool's nodes so the rollout's new pods cannot be scheduled onto them. Cordoning only blocks new scheduling; the pods already running there are unaffected:
+
+   ```bash
+   kubectl cordon -l karpenter.sh/nodepool=materialize
+   ```
+8. Prepare a rollout of your Materialize instances by setting the `force_rollout` field to a new UUID. If you have reverted to the `v1alpha1` version of the Materialize CRD, also set `request_rollout` to the same UUID.
+9. `terraform apply` to perform the rollout. The old pool's nodes are cordoned and the pool is capped, so Karpenter provisions capacity from the new pool for the new-generation pods.
+10. Verify the new environmentd and clusterd pods are running on the new pool's nodes. Once the old nodes are empty, Karpenter consolidates them away (`WhenEmpty`, after 60s); cordoning does not block this.
+11. Remove the old nodepool module instance (with its `termination_grace_period = "300s"` pin and `limits` cap) from your configuration.
+12. `terraform apply` to delete the old NodePool.
+
 #### v5.0.0
 
 The GCP examples default to new machine types for higher performance and due to capacity constraints with the previous types:

--- a/aws/examples/enterprise/main.tf
+++ b/aws/examples/enterprise/main.tf
@@ -179,6 +179,10 @@ module "nodepool_generic" {
   node_labels    = local.generic_node_labels
   expire_after   = "168h"
 
+  # Generic workloads can tolerate eviction, so cap how long draining
+  # pods can delay node replacement.
+  termination_grace_period = "300s"
+
   kubeconfig_data = local.kubeconfig_data
 
   depends_on = [
@@ -221,6 +225,12 @@ module "nodepool_materialize" {
   # the node should have all pods removed from it and be consolidated. You may
   # also delete the node after all clusterd and environmentd pods have been moved off.
   expire_after = "Never"
+
+  # WARNING: leave termination_grace_period unset here. If set, Karpenter
+  # will replace drifted nodes (e.g. after an instance type change) even
+  # though Materialize pods carry the karpenter.sh/do-not-disrupt
+  # annotation, force-evicting them once the deadline passes. Unset, those
+  # pods block disruption until a Materialize rollout moves them.
 
   kubeconfig_data = local.kubeconfig_data
 

--- a/aws/examples/simple/main.tf
+++ b/aws/examples/simple/main.tf
@@ -201,6 +201,10 @@ module "nodepool_generic" {
   node_labels    = local.generic_node_labels
   expire_after   = "168h"
 
+  # Generic workloads can tolerate eviction, so cap how long draining
+  # pods can delay node replacement.
+  termination_grace_period = "300s"
+
   kubeconfig_data = local.kubeconfig_data
 
   depends_on = [
@@ -245,6 +249,12 @@ module "nodepool_materialize" {
   # the node should have all pods removed from it and be consolidated. You may
   # also delete the node after all clusterd and environmentd pods have been moved off.
   expire_after = "Never"
+
+  # WARNING: leave termination_grace_period unset here. If set, Karpenter
+  # will replace drifted nodes (e.g. after an instance type change) even
+  # though Materialize pods carry the karpenter.sh/do-not-disrupt
+  # annotation, force-evicting them once the deadline passes. Unset, those
+  # pods block disruption until a Materialize rollout moves them.
 
   kubeconfig_data = local.kubeconfig_data
 

--- a/aws/modules/karpenter-nodepool/README.md
+++ b/aws/modules/karpenter-nodepool/README.md
@@ -36,10 +36,12 @@ No modules.
 | <a name="input_expire_after"></a> [expire\_after](#input\_expire\_after) | Time after which the node will expire. | `string` | `"Never"` | no |
 | <a name="input_instance_types"></a> [instance\_types](#input\_instance\_types) | List of instance types to support. | `list(string)` | n/a | yes |
 | <a name="input_kubeconfig_data"></a> [kubeconfig\_data](#input\_kubeconfig\_data) | Contents of the kubeconfig used for cleanup of EC2 instances on destroy. | `string` | n/a | yes |
+| <a name="input_limits"></a> [limits](#input\_limits) | Resource limits for the NodePool, e.g. { cpu = "1000" }. Karpenter stops<br/>provisioning new nodes from this pool once the total resources of its<br/>nodes reach these limits; existing nodes are unaffected. Setting<br/>{ cpu = "0" } prevents the pool from provisioning any new nodes, which<br/>is useful when migrating workloads to another pool. Limits are not part<br/>of the NodePool template, so changing them does not drift-replace<br/>existing nodes. | `map(string)` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the NodePool. | `string` | n/a | yes |
 | <a name="input_node_labels"></a> [node\_labels](#input\_node\_labels) | Labels to apply to created Kubernetes nodes. | `map(string)` | n/a | yes |
 | <a name="input_node_taints"></a> [node\_taints](#input\_node\_taints) | Taints to apply to the node. | <pre>list(object({<br/>    key    = string<br/>    value  = string<br/>    effect = string<br/>  }))</pre> | `null` | no |
 | <a name="input_nodeclass_name"></a> [nodeclass\_name](#input\_nodeclass\_name) | Name of the EC2NodeClass. | `string` | n/a | yes |
+| <a name="input_termination_grace_period"></a> [termination\_grace\_period](#input\_termination\_grace\_period) | Maximum time Karpenter will wait for pods to drain before forcefully<br/>terminating a node, e.g. "300s". When set, Karpenter will disrupt nodes<br/>(e.g. on drift after an instance type change) even if they run pods with<br/>the karpenter.sh/do-not-disrupt annotation or blocking PDBs; those pods<br/>are only protected until the node's termination deadline, after which<br/>they are evicted. Leave null so that do-not-disrupt pods (such as<br/>Materialize instance pods) block disruption until they are removed by a<br/>Materialize rollout. | `string` | `null` | no |
 
 ## Outputs
 

--- a/aws/modules/karpenter-nodepool/main.tf
+++ b/aws/modules/karpenter-nodepool/main.tf
@@ -44,37 +44,46 @@ resource "kubectl_manifest" "nodepool" {
       "metadata" : {
         "name" : var.name,
       },
-      "spec" : {
-        "disruption" : var.disruption,
-        "template" : {
-          "metadata" : {
-            "labels" : var.node_labels,
-          },
-          "spec" : {
-            "expireAfter" : var.expire_after,
-            "nodeClassRef" : {
-              "group" : "karpenter.k8s.aws",
-              "kind" : "EC2NodeClass",
-              "name" : var.nodeclass_name,
+      "spec" : merge(
+        {
+          "disruption" : var.disruption,
+          "template" : {
+            "metadata" : {
+              "labels" : var.node_labels,
             },
-            "requirements" : [
+            "spec" : merge(
               {
-                "key" : "node.kubernetes.io/instance-type",
-                "operator" : "In",
-                "values" : var.instance_types,
+                "expireAfter" : var.expire_after,
+                "nodeClassRef" : {
+                  "group" : "karpenter.k8s.aws",
+                  "kind" : "EC2NodeClass",
+                  "name" : var.nodeclass_name,
+                },
+                "requirements" : [
+                  {
+                    "key" : "node.kubernetes.io/instance-type",
+                    "operator" : "In",
+                    "values" : var.instance_types,
+                  },
+                  # TODO zone?
+                  {
+                    "key" : "karpenter.sh/capacity-type",
+                    "operator" : "In",
+                    "values" : ["on-demand"],
+                  },
+                ],
+                "taints" : var.node_taints,
               },
-              # TODO zone?
-              {
-                "key" : "karpenter.sh/capacity-type",
-                "operator" : "In",
-                "values" : ["on-demand"],
-              },
-            ],
-            "taints" : var.node_taints,
-            "terminationGracePeriod" : "300s",
+              var.termination_grace_period != null ? {
+                "terminationGracePeriod" : var.termination_grace_period,
+              } : {},
+            ),
           },
         },
-      },
+        var.limits != null ? {
+          "limits" : var.limits,
+        } : {},
+      ),
     }
   )
 

--- a/aws/modules/karpenter-nodepool/variables.tf
+++ b/aws/modules/karpenter-nodepool/variables.tf
@@ -48,6 +48,35 @@ variable "expire_after" {
   default     = "Never"
 }
 
+variable "termination_grace_period" {
+  description = <<-EOT
+    Maximum time Karpenter will wait for pods to drain before forcefully
+    terminating a node, e.g. "300s". When set, Karpenter will disrupt nodes
+    (e.g. on drift after an instance type change) even if they run pods with
+    the karpenter.sh/do-not-disrupt annotation or blocking PDBs; those pods
+    are only protected until the node's termination deadline, after which
+    they are evicted. Leave null so that do-not-disrupt pods (such as
+    Materialize instance pods) block disruption until they are removed by a
+    Materialize rollout.
+  EOT
+  type        = string
+  default     = null
+}
+
+variable "limits" {
+  description = <<-EOT
+    Resource limits for the NodePool, e.g. { cpu = "1000" }. Karpenter stops
+    provisioning new nodes from this pool once the total resources of its
+    nodes reach these limits; existing nodes are unaffected. Setting
+    { cpu = "0" } prevents the pool from provisioning any new nodes, which
+    is useful when migrating workloads to another pool. Limits are not part
+    of the NodePool template, so changing them does not drift-replace
+    existing nodes.
+  EOT
+  type        = map(string)
+  default     = null
+}
+
 variable "node_taints" {
   description = "Taints to apply to the node."
   type = list(object({


### PR DESCRIPTION
Hardcoded 300s let Karpenter bypass karpenter.sh/do-not-disrupt and PDBs on drifted nodes, force-evicting Materialize pods 5 minutes after an instance type change. Default null so do-not-disrupt pods block disruption until a Materialize rollout moves them; generic pools set 300s explicitly since their workloads tolerate eviction.