### PR TITLE
docs(gcp): document required IAM roles for the deploying principal

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -100,3 +100,7 @@ provider "helm" {
 ### Required APIs
 
 Your GCP project needs several APIs enabled. See the [examples/simple/README.md](./examples/simple/README.md#required-apis) for the complete list of required APIs and how to enable them.
+
+### Required IAM roles
+
+The identity running Terraform must be able to create every resource in these modules. Deploying as a project Owner/Editor covers this; for a least-privilege or CI (Workload Identity Federation) principal, see [Required IAM roles](./examples/simple/README.md#required-iam-roles) in the simple example. Note that enabling an API is separate from being granted the IAM role that uses it — most notably `servicenetworking.googleapis.com` (API) versus `roles/servicenetworking.networksAdmin` (role) for Cloud SQL's private IP.

--- a/gcp/examples/simple/README.md
+++ b/gcp/examples/simple/README.md
@@ -62,6 +62,56 @@ gcloud services enable iam.googleapis.com                     # For managing IAM
 gcloud services enable storage.googleapis.com                 # For Cloud Storage buckets
 ```
 
+## Required IAM roles
+
+The identity that runs Terraform — a user via `gcloud auth application-default
+login`, or a CI service account / Workload Identity Federation principal — must
+be able to create every resource in these modules. If you deploy as a project
+**Owner** or **Editor** (common for interactive use), this is already covered
+and you can skip this section.
+
+If you run under **least privilege** (recommended for CI), grant the deploying
+principal these roles on the project. This is a working starting point for what
+the GCP modules create:
+
+| Role | Needed for |
+|------|------------|
+| `roles/compute.networkAdmin` | VPC, subnets, routes, and firewall rules |
+| `roles/servicenetworking.networksAdmin` | Private Services Access peering used by Cloud SQL's private IP |
+| `roles/container.admin` | GKE cluster and node pools (also grants the creating identity cluster-admin RBAC, which the Kubernetes and Helm providers rely on) |
+| `roles/cloudsql.admin` | Cloud SQL instance, databases, and users |
+| `roles/storage.admin` | Cloud Storage bucket, HMAC keys, and bucket IAM bindings |
+| `roles/iam.serviceAccountAdmin` | Creating the GKE node and Materialize Workload Identity service accounts and setting their IAM policy |
+| `roles/iam.serviceAccountUser` | Allowing GKE nodes to run as the node service account (`actAs`) |
+
+```bash
+# Example: grant the roles to a CI service account on the project
+PROJECT=my-gcp-project
+PRINCIPAL="serviceAccount:terraform@my-gcp-project.iam.gserviceaccount.com"
+for role in \
+  roles/compute.networkAdmin \
+  roles/servicenetworking.networksAdmin \
+  roles/container.admin \
+  roles/cloudsql.admin \
+  roles/storage.admin \
+  roles/iam.serviceAccountAdmin \
+  roles/iam.serviceAccountUser; do
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member="$PRINCIPAL" --role="$role" --condition=None
+done
+```
+
+> **Commonly missed:** without `roles/servicenetworking.networksAdmin`, apply
+> fails at the private-services connection with `Error 403: Permission denied to
+> add peering for service 'servicenetworking.googleapis.com'` — even when the
+> Service Networking **API** is enabled. The API and the IAM role are separate
+> requirements: enabling the API is necessary but not sufficient.
+
+If you extend these modules — for example a cert-manager ACME DNS-01 issuer that
+manages a Cloud DNS zone, or resources that create service-account keys or
+project IAM bindings — grant the matching roles as well (`roles/dns.admin`,
+`roles/iam.serviceAccountKeyAdmin`, `roles/resourcemanager.projectIamAdmin`).
+
 ## Getting Started
 
 ### Step 1: Set Required Variables

--- a/gcp/examples/simple/README.md
+++ b/gcp/examples/simple/README.md
@@ -71,12 +71,7 @@ be able to create every resource in these modules. If you deploy as a project
 and you can skip this section.
 
 If you run under **least privilege** (recommended for CI), grant the deploying
-principal these roles on the project. Project Owner/Editor bundles most of these
-implicitly, so a gap does not appear until you drop to least privilege — and
-then it surfaces as a separate `403` (or `401`) partway through an apply, often
-after real infrastructure has already been created. The set below is a working
-starting point for what the GCP modules create, validated end-to-end against a
-full deployment:
+principal these roles on the project.
 
 | Role | Needed for |
 |------|------------|

--- a/gcp/examples/simple/README.md
+++ b/gcp/examples/simple/README.md
@@ -107,6 +107,39 @@ done
 > Service Networking **API** is enabled. The API and the IAM role are separate
 > requirements: enabling the API is necessary but not sufficient.
 
+### Authenticating to GKE from CI (Workload Identity Federation)
+
+These modules configure the `kubernetes` and `helm` providers with a token from
+`data.google_client_config`, i.e. the identity Terraform runs as. GKE maps that
+identity to Kubernetes RBAC — and it resolves the mapping for a Google
+**service account**, not for a **direct Workload Identity Federation
+principal**. So if CI authenticates as the federated principal directly, cluster
+creation (a Google API call) succeeds, but every `kubernetes_*` / `helm_*`
+resource then fails with:
+
+```
+Error: Unauthorized
+```
+
+This is an authentication (HTTP 401) failure, not a missing IAM role — adding
+project roles will not fix it.
+
+**Fix:** have CI impersonate a Google service account instead of using the
+federated principal directly. With
+[`google-github-actions/auth`](https://github.com/google-github-actions/auth):
+
+```yaml
+- uses: google-github-actions/auth@v2
+  with:
+    workload_identity_provider: ${{ vars.WIF_PROVIDER }}
+    service_account: terraform@my-gcp-project.iam.gserviceaccount.com  # impersonate
+```
+
+Grant that service account the roles in the table above (its
+`roles/container.admin` is what supplies the cluster-admin RBAC mapping), and
+grant the federated principal `roles/iam.serviceAccountTokenCreator` on the
+service account so it may impersonate it.
+
 If you extend these modules — for example a cert-manager ACME DNS-01 issuer that
 manages a Cloud DNS zone, or resources that create service-account keys or
 project IAM bindings — grant the matching roles as well (`roles/dns.admin`,

--- a/gcp/examples/simple/README.md
+++ b/gcp/examples/simple/README.md
@@ -71,8 +71,12 @@ be able to create every resource in these modules. If you deploy as a project
 and you can skip this section.
 
 If you run under **least privilege** (recommended for CI), grant the deploying
-principal these roles on the project. This is a working starting point for what
-the GCP modules create:
+principal these roles on the project. Project Owner/Editor bundles most of these
+implicitly, so a gap does not appear until you drop to least privilege — and
+then it surfaces as a separate `403` (or `401`) partway through an apply, often
+after real infrastructure has already been created. The set below is a working
+starting point for what the GCP modules create, validated end-to-end against a
+full deployment:
 
 | Role | Needed for |
 |------|------------|
@@ -82,7 +86,7 @@ the GCP modules create:
 | `roles/cloudsql.admin` | Cloud SQL instance, databases, and users |
 | `roles/storage.admin` | Cloud Storage bucket and bucket IAM bindings |
 | `roles/storage.hmacKeyAdmin` | HMAC key for the GCS S3-compatible persist backend (see note — `roles/storage.admin` does **not** include HMAC key permissions) |
-| `roles/iam.serviceAccountAdmin` | Creating the GKE node and Materialize Workload Identity service accounts and setting their IAM policy |
+| `roles/iam.serviceAccountAdmin` | Creating the GKE node and Materialize Workload Identity service accounts **and** setting their IAM policy for the Workload Identity binding. The narrower `roles/iam.serviceAccountCreator` is not enough — it lacks `iam.serviceAccounts.setIamPolicy`, so the binding fails with a `403`. |
 | `roles/iam.serviceAccountUser` | Allowing GKE nodes to run as the node service account (`actAs`) |
 
 ```bash
@@ -110,11 +114,10 @@ done
 > requirements: enabling the API is necessary but not sufficient.
 
 > **Also commonly missed:** `roles/storage.admin` does **not** grant HMAC key
-> permissions (`storage.hmacKeys.*`). The GCP storage module creates an HMAC key
-> for the S3-compatible persist backend, so without `roles/storage.hmacKeyAdmin`
-> apply/plan fails with `Error 403: ... does not have storage.hmacKeys.get
-> access`. Project **Owner/Editor** includes these permissions implicitly, which
-> is why this only surfaces under least privilege.
+> permissions (`storage.hmacKeys.*`), despite the name. The GCP storage module
+> creates an HMAC key for the S3-compatible persist backend, so without
+> `roles/storage.hmacKeyAdmin` apply/plan fails with `Error 403: ... does not
+> have storage.hmacKeys.get access`.
 
 ### Authenticating to GKE from CI (Workload Identity Federation)
 

--- a/gcp/examples/simple/README.md
+++ b/gcp/examples/simple/README.md
@@ -80,7 +80,8 @@ the GCP modules create:
 | `roles/servicenetworking.networksAdmin` | Private Services Access peering used by Cloud SQL's private IP |
 | `roles/container.admin` | GKE cluster and node pools (also grants the creating identity cluster-admin RBAC, which the Kubernetes and Helm providers rely on) |
 | `roles/cloudsql.admin` | Cloud SQL instance, databases, and users |
-| `roles/storage.admin` | Cloud Storage bucket, HMAC keys, and bucket IAM bindings |
+| `roles/storage.admin` | Cloud Storage bucket and bucket IAM bindings |
+| `roles/storage.hmacKeyAdmin` | HMAC key for the GCS S3-compatible persist backend (see note — `roles/storage.admin` does **not** include HMAC key permissions) |
 | `roles/iam.serviceAccountAdmin` | Creating the GKE node and Materialize Workload Identity service accounts and setting their IAM policy |
 | `roles/iam.serviceAccountUser` | Allowing GKE nodes to run as the node service account (`actAs`) |
 
@@ -94,6 +95,7 @@ for role in \
   roles/container.admin \
   roles/cloudsql.admin \
   roles/storage.admin \
+  roles/storage.hmacKeyAdmin \
   roles/iam.serviceAccountAdmin \
   roles/iam.serviceAccountUser; do
   gcloud projects add-iam-policy-binding "$PROJECT" \
@@ -106,6 +108,13 @@ done
 > add peering for service 'servicenetworking.googleapis.com'` — even when the
 > Service Networking **API** is enabled. The API and the IAM role are separate
 > requirements: enabling the API is necessary but not sufficient.
+
+> **Also commonly missed:** `roles/storage.admin` does **not** grant HMAC key
+> permissions (`storage.hmacKeys.*`). The GCP storage module creates an HMAC key
+> for the S3-compatible persist backend, so without `roles/storage.hmacKeyAdmin`
+> apply/plan fails with `Error 403: ... does not have storage.hmacKeys.get
+> access`. Project **Owner/Editor** includes these permissions implicitly, which
+> is why this only surfaces under least privilege.
 
 ### Authenticating to GKE from CI (Workload Identity Federation)
 


### PR DESCRIPTION
## Problem

The GCP docs cover which **APIs** to enable, but never the **IAM roles** the identity running Terraform needs, nor how CI must authenticate to GKE. All of this is invisible when you deploy as a project **Owner/Editor** via interactive `gcloud auth application-default login` — that role bundle grants everything implicitly. It bites hard under **least privilege** (e.g. a CI Workload Identity Federation principal), where each missing grant surfaces as a separate `403`/`401` partway through an apply, often after real infrastructure already exists.

Concrete failures hit in that setup, none documented:

1. **Private-services peering** — `Error 403: Permission denied to add peering for service 'servicenetworking.googleapis.com'`, **even though the API is enabled** (the API and `roles/servicenetworking.networksAdmin` are separate requirements).
2. **GKE auth** — the cluster gets created, then every `kubernetes_*`/`helm_*` resource fails with `Error: Unauthorized`. This is a 401: GKE maps IAM→RBAC for Google **service accounts**, not for **direct WIF principals**. No project role fixes it.
3. **HMAC keys** — `Error 403: ... does not have storage.hmacKeys.get access`. `roles/storage.admin` does **not** include HMAC key permissions, and the storage module needs an HMAC key for the S3-compatible persist backend.
4. **Workload Identity binding** — `Error 403: Permission 'iam.serviceAccounts.setIamPolicy' denied`. The tempting narrower `roles/iam.serviceAccountCreator` lacks `setIamPolicy`; you need `roles/iam.serviceAccountAdmin`.

## Change

Docs-only. Adds a **Required IAM roles** section to `gcp/examples/simple/README.md` and links it from `gcp/README.md`:

- The organizing principle up front (Owner/Editor masks these; least privilege surfaces each gap).
- A least-privilege role table (validated end-to-end against a full deployment) with a copy-paste `gcloud` grant loop: `compute.networkAdmin`, `servicenetworking.networksAdmin`, `container.admin`, `cloudsql.admin`, `storage.admin`, `storage.hmacKeyAdmin`, `iam.serviceAccountAdmin`, `iam.serviceAccountUser`.
- Callouts for the two non-obvious traps (API-vs-role for servicenetworking; `storage.admin` ≠ HMAC keys) and the `serviceAccountCreator`-vs-`serviceAccountAdmin` distinction.
- An **Authenticating to GKE from CI (WIF)** subsection: the `Error: Unauthorized` 401 and its fix — impersonate a service account via `google-github-actions/auth`, and grant the federated principal `roles/iam.serviceAccountTokenCreator` on it.
- A note to add `roles/dns.admin`, `roles/iam.serviceAccountKeyAdmin`, `roles/resourcemanager.projectIamAdmin` if you extend the modules (e.g. a cert-manager DNS-01 issuer).

## Context

Surfaced and then verified while deploying self-managed Materialize on GKE through a WIF-authenticated GitHub Actions runner using a least-privilege dedicated service account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)