### PR TITLE
fix(examples): operator must depend on cert-manager in enterprise examples

### DIFF
--- a/aws/examples/enterprise/main.tf
+++ b/aws/examples/enterprise/main.tf
@@ -340,6 +340,10 @@ module "operator" {
     module.nodepool_generic,
     module.coredns,
     module.vpc_cni,
+    # The operator Helm chart renders cert-manager Certificate/Issuer resources
+    # for its own TLS, so cert-manager (its CRDs) must be installed first. The
+    # simple example already declares this; keep the enterprise example in sync.
+    module.cert_manager,
   ]
 }
 

--- a/aws/examples/enterprise/main.tf
+++ b/aws/examples/enterprise/main.tf
@@ -340,9 +340,6 @@ module "operator" {
     module.nodepool_generic,
     module.coredns,
     module.vpc_cni,
-    # The operator Helm chart renders cert-manager Certificate/Issuer resources
-    # for its own TLS, so cert-manager (its CRDs) must be installed first. The
-    # simple example already declares this; keep the enterprise example in sync.
     module.cert_manager,
   ]
 }

--- a/azure/examples/enterprise/main.tf
+++ b/azure/examples/enterprise/main.tf
@@ -427,6 +427,10 @@ module "operator" {
     module.database,
     module.storage,
     module.coredns,
+    # The operator Helm chart renders cert-manager Certificate/Issuer resources
+    # for its own TLS, so cert-manager (its CRDs) must be installed first. The
+    # simple example already declares this; keep the enterprise example in sync.
+    module.cert_manager,
   ]
 }
 

--- a/azure/examples/enterprise/main.tf
+++ b/azure/examples/enterprise/main.tf
@@ -427,9 +427,6 @@ module "operator" {
     module.database,
     module.storage,
     module.coredns,
-    # The operator Helm chart renders cert-manager Certificate/Issuer resources
-    # for its own TLS, so cert-manager (its CRDs) must be installed first. The
-    # simple example already declares this; keep the enterprise example in sync.
     module.cert_manager,
   ]
 }

--- a/gcp/examples/enterprise/main.tf
+++ b/gcp/examples/enterprise/main.tf
@@ -404,9 +404,6 @@ module "operator" {
     module.gke,
     module.generic_nodepool,
     module.coredns,
-    # The operator Helm chart renders cert-manager Certificate/Issuer resources
-    # for its own TLS, so cert-manager (its CRDs) must be installed first. The
-    # simple example already declares this; keep the enterprise example in sync.
     module.cert_manager,
   ]
 }

--- a/gcp/examples/enterprise/main.tf
+++ b/gcp/examples/enterprise/main.tf
@@ -404,6 +404,10 @@ module "operator" {
     module.gke,
     module.generic_nodepool,
     module.coredns,
+    # The operator Helm chart renders cert-manager Certificate/Issuer resources
+    # for its own TLS, so cert-manager (its CRDs) must be installed first. The
+    # simple example already declares this; keep the enterprise example in sync.
+    module.cert_manager,
   ]
 }
 


### PR DESCRIPTION
## Problem

Deploying any `enterprise` example fails during apply at the operator Helm release:

```
Error: unable to build kubernetes objects from release manifest:
  no matches for kind "Certificate" in version "cert-manager.io/v1"
  ensure CRDs are installed first
  (also "Issuer"; for <prefix>-materialize-operator-{ca,cert,self-signed})
  with module.operator.helm_release.materialize_operator
```

The operator Helm chart renders cert-manager `Certificate`/`Issuer` resources for the operator's own TLS, so cert-manager (and its CRDs) must be installed **before** the operator chart.

## Root cause

All three **`simple`** examples declare `module.cert_manager` in the operator's `depends_on`, but the **`enterprise`** examples (aws, azure, gcp) omit it:

| example | `operator` depends on `cert_manager`? |
|---------|:--:|
| aws/simple, azure/simple, gcp/simple | ✅ |
| aws/enterprise, azure/enterprise, gcp/enterprise | ❌ |

Terraform installs cert-manager and the operator in parallel, so the operator chart gets applied before cert-manager registers its CRDs → the error above. It reproduces deterministically.

## Testing

Verified against a full GCP enterprise deployment: with the dependency added, the operator chart installs after cert-manager and the `no matches for kind "Certificate"` error no longer occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)