### PR TITLE
fix(grafana): use persistence.storageClassName, not storageClass

### DIFF
--- a/kubernetes/modules/grafana/main.tf
+++ b/kubernetes/modules/grafana/main.tf
@@ -51,9 +51,9 @@ locals {
     adminPassword = local.admin_password
 
     persistence = {
-      enabled      = true
-      size         = var.storage_size
-      storageClass = var.storage_class
+      enabled          = true
+      size             = var.storage_size
+      storageClassName = var.storage_class
     }
 
     resources = {


### PR DESCRIPTION
## Problem

The grafana module never honors its `storage_class` input. It sets the Helm value `persistence.storageClass`, but the grafana chart's key is **`persistence.storageClassName`**. The value is silently ignored and the PVC falls back to the cluster's **default** StorageClass.

This is latent whenever the passed class equals the default, so it went unnoticed. It breaks when a different class is required — e.g. on GKE with **C4** nodes, where the default `standard-rwo` (pd-balanced) volume cannot attach (`pd-balanced disk type cannot be used by c4-standard-8 machine type`), leaving Grafana stuck in `Init` and its Helm release timing out with `context deadline exceeded`.

## Fix

`persistence.storageClass` → `persistence.storageClassName` (the chart's actual key), so `var.storage_class` is applied to the PVC.

## Verified

Confirmed against the grafana chart values (`persistence.storageClassName`) and reproduced on a live GKE C4 deployment: with the wrong key the Grafana PVC used the default class and failed to attach; the Prometheus module (which wires the value correctly) worked with the same requested class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)