### PR TITLE
feat(materialize-instance): add environment_id input for spec.environmentId

### DIFF
--- a/kubernetes/modules/materialize-instance/main.tf
+++ b/kubernetes/modules/materialize-instance/main.tf
@@ -107,6 +107,12 @@ resource "kubectl_manifest" "materialize_instance" {
       # requestRollout only applies to v1alpha1
       var.crd_version == "v1alpha1" ? {
         requestRollout = var.request_rollout
+      } : {},
+      # Only set environmentId when provided; otherwise the operator applies its
+      # default. Required to match a license key issued for a specific
+      # environment_id (the operator rejects a mismatch).
+      var.environment_id != null ? {
+        environmentId = var.environment_id
       } : {}
     )
   })

--- a/kubernetes/modules/materialize-instance/variables.tf
+++ b/kubernetes/modules/materialize-instance/variables.tf
@@ -49,6 +49,12 @@ variable "license_key" {
   sensitive   = true
 }
 
+variable "environment_id" {
+  description = "Value for spec.environmentId on the Materialize CR. Leave null to let the operator apply its default. Set this to match the environment_id embedded in the license key (aud/sub); the operator rejects the resource if the CR's environment_id does not match the license key's."
+  type        = string
+  default     = null
+}
+
 # Environmentd Configuration
 variable "environmentd_version" {
   description = "Version of environmentd to use"


### PR DESCRIPTION
## Problem

The Materialize operator validates that the Materialize resource's `spec.environmentId` matches the `environment_id` embedded in the license key (the license `aud`/`sub`). When they differ, reconcile fails and no environment is created:

```
failed to apply object: environment_id is set in materialize resource
<ns>/<name> but does not match the environment_id set in the associated
license key <uuid>
```

The `materialize-instance` module provided no way to set `spec.environmentId`, so a license issued for a specific `environment_id` could not be deployed at all.

## Change

Add an optional `environment_id` variable, merged into the CR spec **only when set**. Default `null` preserves current behavior (operator applies its own default), so this is fully backward compatible.

```hcl
module "materialize_instance" {
  # ...
  environment_id = "00000000-0000-0000-0000-000000000000"  # match the license key
}
```

## Verified

On a live GKE deployment with a production-signed license bound to a specific `environment_id`: without this the operator rejected the resource with the error above; setting `environment_id` to the license's value let the operator reconcile (`UpToDate=True`) and bring up environmentd/clusterd/balancerd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)