### PR TITLE
feat(gcp): blue-green node pool upgrades + node upgrade rollout trigger

### DIFF
--- a/gcp/examples/enterprise/main.tf
+++ b/gcp/examples/enterprise/main.tf
@@ -4,6 +4,14 @@ provider "google" {
   default_labels = var.labels
 }
 
+# Used by the nodepool module for autoscaled blue-green upgrade settings,
+# which are not yet available in the GA google provider.
+provider "google-beta" {
+  project        = var.project_id
+  region         = var.region
+  default_labels = var.labels
+}
+
 # Configure kubernetes provider with GKE cluster credentials
 data "google_client_config" "default" {}
 
@@ -217,6 +225,10 @@ module "gke" {
   # Cache DNS lookups on every node. On Dataplane V2 the GKE addon is the only
   # working node-local DNS option (see the variable description in the module).
   enable_node_local_dns = true
+
+  # Publish upgrade notifications to Pub/Sub for the node upgrade rollout
+  # trigger (see the operator module below).
+  enable_upgrade_notifications = var.enable_node_upgrade_rollout_trigger
 }
 
 # Create and configure generic node pool for all workloads except Materialize
@@ -387,6 +399,19 @@ module "operator" {
   # node selector for operator and metrics-server workloads
   operator_node_selector = local.generic_node_labels
 
+  # Trigger rollouts of Materialize instances when GKE upgrades the node
+  # pools they run on, so that their pods move to the replacement nodes
+  # gracefully instead of being evicted.
+  enable_node_upgrade_rollout_trigger    = var.enable_node_upgrade_rollout_trigger
+  node_upgrade_notification_subscription = module.gke.upgrade_notification_subscription
+  cluster_name                           = module.gke.cluster_name
+  cluster_location                       = module.gke.cluster_location
+  node_upgrade_watched_node_pools        = [module.materialize_nodepool.node_pool_name]
+  # Grant the operator workload identity access for its Pub/Sub subscription
+  # and GKE API reads.
+  operator_service_account_annotations = var.enable_node_upgrade_rollout_trigger ? {
+    "iam.gke.io/gcp-service-account" = module.gke.workload_identity_sa_email
+  } : {}
 
   # Enable Prometheus scrape annotations when observability is enabled
   helm_values = var.enable_observability ? {

--- a/gcp/examples/enterprise/main.tf
+++ b/gcp/examples/enterprise/main.tf
@@ -392,6 +392,10 @@ module "operator" {
   name_prefix = var.name_prefix
   region      = var.region
 
+  # Must match the namespace passed to the gke module: its workload identity
+  # binding targets the operator's service account in that namespace.
+  operator_namespace = local.materialize_operator_namespace
+
   # ARM tolerations and node selector for all operator workloads on GCP
   instance_pod_tolerations = local.materialize_tolerations
   instance_node_selector   = local.materialize_node_labels
@@ -408,7 +412,9 @@ module "operator" {
   cluster_location                       = module.gke.cluster_location
   node_upgrade_watched_node_pools        = [module.materialize_nodepool.node_pool_name]
   # Grant the operator workload identity access for its Pub/Sub subscription
-  # and GKE API reads.
+  # and GKE API reads. The gke module's workload identity binding targets the
+  # chart's service account (its orchestratord_service_account_name variable,
+  # default "orchestratord") in the operator namespace.
   operator_service_account_annotations = var.enable_node_upgrade_rollout_trigger ? {
     "iam.gke.io/gcp-service-account" = module.gke.workload_identity_sa_email
   } : {}

--- a/gcp/examples/enterprise/variables.tf
+++ b/gcp/examples/enterprise/variables.tf
@@ -204,3 +204,10 @@ variable "datapath_provider" {
     error_message = "Datapath provider must be one of ADVANCED_DATAPATH, LEGACY_DATAPATH, or DATAPATH_PROVIDER_UNSPECIFIED"
   }
 }
+
+variable "enable_node_upgrade_rollout_trigger" {
+  description = "Trigger rollouts of Materialize instances when GKE upgrades the node pools they run on, moving their pods to the replacement nodes gracefully instead of letting GKE evict them."
+  type        = bool
+  default     = true
+  nullable    = false
+}

--- a/gcp/examples/enterprise/versions.tf
+++ b/gcp/examples/enterprise/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 7.22, < 8"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 7.22, < 8"
+    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 2.0"

--- a/gcp/examples/migration/.terraform.lock.hcl
+++ b/gcp/examples/migration/.terraform.lock.hcl
@@ -45,6 +45,26 @@ provider "registry.terraform.io/hashicorp/google" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "7.40.0"
+  constraints = ">= 7.22.0, < 8.0.0"
+  hashes = [
+    "h1:o7TK9dRZADXVHTJhLZjSV1gnY4H0EngWCyf7ae7t/Xg=",
+    "zh:3946350745941274a43e561d351fa4a051929883ad7bb52230c59f0e8b44e302",
+    "zh:3befd2d7210a1224563abd0d6b1d0cae14710f078b98fc81f7eb370ee9ddff3e",
+    "zh:846da1ca7b81b32ea5c70b0ca388212ef12fd6f6d73b7e7ce98c5d2c1d033f7b",
+    "zh:970646fe1568ad35826f929826536be51bc547a8e59a335b4202860670fe9938",
+    "zh:99e29f3778a1a10ee7687fcd55dcc151a0ff62b23281c19b7e2f2cda5c10556d",
+    "zh:9cbf88359119afdd7c4bbe5fc02cc43e635a8a34a3b474e66e89cef26592542c",
+    "zh:a41da7c4d69f418f93f12529a630c2af9870f917959b0a2018e7f12ab848b7f6",
+    "zh:df1bad58418a7380a99bbfb09fbfe18120af2d7667547149cd4f65713e232330",
+    "zh:e48c1d7db3e4b3d7585a212a8cbc4e9f8853844f3d6262f98993c164ddd9249d",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fc84ba75a392bd404607ce1760cb9b3bae0632505976e1d3c2cf98217a9bb881",
+    "zh:ff93e1841b6b3876c95ee40a4e3889a0efb4347a24067f53c18ffaa0503de4f0",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.17.0"
   constraints = "~> 2.0, >= 2.5.0, < 2.18.0"

--- a/gcp/examples/migration/main.tf
+++ b/gcp/examples/migration/main.tf
@@ -37,6 +37,13 @@ provider "google" {
   # explicitly on resources that need them (Cloud SQL, GCS, node pools).
 }
 
+# Used by the nodepool module for autoscaled blue-green upgrade settings,
+# which are not yet available in the GA google provider.
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
 data "google_client_config" "default" {}
 
 provider "kubernetes" {
@@ -387,8 +394,10 @@ resource "google_sql_user" "materialize" {
 # MODULE: Materialize Node Pool
 # =============================================================================
 # The nodepool module's google_container_node_pool resource has the same
-# structure as the old module. The kubernetes resources (disk setup daemonset)
-# will be recreated with shorter names but that's non-disruptive.
+# structure as the old module, except that it now configures blue-green
+# upgrade settings, which are applied in-place (non-disruptive). The
+# kubernetes resources (disk setup daemonset) will be recreated with shorter
+# names but that's non-disruptive.
 # =============================================================================
 
 module "materialize_nodepool" {

--- a/gcp/examples/migration/versions.tf
+++ b/gcp/examples/migration/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 7.22, < 8"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 7.22, < 8"
+    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 2.0, < 2.39.0"

--- a/gcp/examples/simple/main.tf
+++ b/gcp/examples/simple/main.tf
@@ -348,6 +348,10 @@ module "operator" {
   name_prefix = var.name_prefix
   region      = var.region
 
+  # Must match the namespace passed to the gke module: its workload identity
+  # binding targets the operator's service account in that namespace.
+  operator_namespace = local.materialize_operator_namespace
+
   # ARM tolerations and node selector for all operator workloads on GCP
   instance_pod_tolerations = local.materialize_tolerations
   instance_node_selector   = local.materialize_node_labels
@@ -364,11 +368,12 @@ module "operator" {
   cluster_location                       = module.gke.cluster_location
   node_upgrade_watched_node_pools        = [module.materialize_nodepool.node_pool_name]
   # Grant the operator workload identity access for its Pub/Sub subscription
-  # and GKE API reads.
+  # and GKE API reads. The gke module's workload identity binding targets the
+  # chart's service account (its orchestratord_service_account_name variable,
+  # default "orchestratord") in the operator namespace.
   operator_service_account_annotations = var.enable_node_upgrade_rollout_trigger ? {
     "iam.gke.io/gcp-service-account" = module.gke.workload_identity_sa_email
   } : {}
-
 
   # Enable Prometheus scrape annotations when observability is enabled
   helm_values = var.enable_observability ? {

--- a/gcp/examples/simple/main.tf
+++ b/gcp/examples/simple/main.tf
@@ -4,6 +4,14 @@ provider "google" {
   default_labels = var.labels
 }
 
+# Used by the nodepool module for autoscaled blue-green upgrade settings,
+# which are not yet available in the GA google provider.
+provider "google-beta" {
+  project        = var.project_id
+  region         = var.region
+  default_labels = var.labels
+}
+
 # Configure kubernetes provider with GKE cluster credentials
 data "google_client_config" "default" {}
 
@@ -195,6 +203,10 @@ module "gke" {
   # working node-local DNS option (see the variable description in the module).
   enable_node_local_dns = true
 
+  # Publish upgrade notifications to Pub/Sub for the node upgrade rollout
+  # trigger (see the operator module below).
+  enable_upgrade_notifications = var.enable_node_upgrade_rollout_trigger
+
   # Pinned to STABLE: REGULAR's 1.35.x line regressed cleanup of the per-cluster
   # k8s-<cluster-uid>-node-http-hc firewall on cluster destroy, leaving the VPC
   # un-deletable. STABLE is still on 1.34.x which doesn't have the regression.
@@ -342,6 +354,20 @@ module "operator" {
 
   # node selector for operator and metrics-server workloads
   operator_node_selector = local.generic_node_labels
+
+  # Trigger rollouts of Materialize instances when GKE upgrades the node
+  # pools they run on, so that their pods move to the replacement nodes
+  # gracefully instead of being evicted.
+  enable_node_upgrade_rollout_trigger    = var.enable_node_upgrade_rollout_trigger
+  node_upgrade_notification_subscription = module.gke.upgrade_notification_subscription
+  cluster_name                           = module.gke.cluster_name
+  cluster_location                       = module.gke.cluster_location
+  node_upgrade_watched_node_pools        = [module.materialize_nodepool.node_pool_name]
+  # Grant the operator workload identity access for its Pub/Sub subscription
+  # and GKE API reads.
+  operator_service_account_annotations = var.enable_node_upgrade_rollout_trigger ? {
+    "iam.gke.io/gcp-service-account" = module.gke.workload_identity_sa_email
+  } : {}
 
 
   # Enable Prometheus scrape annotations when observability is enabled

--- a/gcp/examples/simple/variables.tf
+++ b/gcp/examples/simple/variables.tf
@@ -96,3 +96,10 @@ variable "datapath_provider" {
     error_message = "Datapath provider must be one of ADVANCED_DATAPATH, LEGACY_DATAPATH, or DATAPATH_PROVIDER_UNSPECIFIED"
   }
 }
+
+variable "enable_node_upgrade_rollout_trigger" {
+  description = "Trigger rollouts of Materialize instances when GKE upgrades the node pools they run on, moving their pods to the replacement nodes gracefully instead of letting GKE evict them."
+  type        = bool
+  default     = true
+  nullable    = false
+}

--- a/gcp/examples/simple/versions.tf
+++ b/gcp/examples/simple/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 7.22, < 8"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 7.22, < 8"
+    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 2.0, < 2.39.0"

--- a/gcp/modules/gke/README.md
+++ b/gcp/modules/gke/README.md
@@ -46,6 +46,7 @@ No modules.
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | The namespace where the Materialize Operator will be installed | `string` | n/a | yes |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | The name of the VPC network | `string` | n/a | yes |
 | <a name="input_networking_mode"></a> [networking\_mode](#input\_networking\_mode) | The networking mode for the GKE cluster | `string` | `"VPC_NATIVE"` | no |
+| <a name="input_orchestratord_service_account_name"></a> [orchestratord\_service\_account\_name](#input\_orchestratord\_service\_account\_name) | The name of the operator's Kubernetes service account bound to the workload identity service account. Must match the Materialize operator chart's serviceAccount.name value (the operator module leaves this at the chart default, "orchestratord"). | `string` | `"orchestratord"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix to be used for resource names | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project where resources will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region where resources will be created | `string` | n/a | yes |

--- a/gcp/modules/gke/README.md
+++ b/gcp/modules/gke/README.md
@@ -21,6 +21,10 @@ No modules.
 | ---- | ---- |
 | [google_compute_firewall.conversion_webhook](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_container_cluster.primary](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster) | resource |
+| [google_project_iam_member.orchestratord_cluster_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_pubsub_subscription.orchestratord_upgrade_notifications](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
+| [google_pubsub_subscription_iam_member.orchestratord_upgrade_notifications_subscriber](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam_member) | resource |
+| [google_pubsub_topic.upgrade_notifications](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
 | [google_service_account.gke_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.workload_identity_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account_iam_binding.workload_identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
@@ -32,6 +36,7 @@ No modules.
 | <a name="input_cluster_secondary_range_name"></a> [cluster\_secondary\_range\_name](#input\_cluster\_secondary\_range\_name) | The name of the secondary range to use for pods | `string` | `"pods"` | no |
 | <a name="input_datapath_provider"></a> [datapath\_provider](#input\_datapath\_provider) | The datapath provider (CNI) for the GKE cluster. ADVANCED\_DATAPATH is GKE Dataplane V2 (eBPF-based, enforces Kubernetes NetworkPolicy natively). DATAPATH\_PROVIDER\_UNSPECIFIED and LEGACY\_DATAPATH use the legacy GKE CNI, which silently ignores NetworkPolicy resources. GKE cannot change the datapath provider on an existing cluster: changing this forces the cluster to be rebuilt. | `string` | `"ADVANCED_DATAPATH"` | no |
 | <a name="input_enable_node_local_dns"></a> [enable\_node\_local\_dns](#input\_enable\_node\_local\_dns) | Whether to enable GKE's NodeLocal DNSCache addon, which runs a DNS cache on every node. This is the supported way to get node-local DNS on GKE: with Dataplane V2 a self-deployed node-local-dns cannot intercept kube-dns traffic (service IPs are rewritten in eBPF before iptables sees them). Note: NodeLocal DNSCache caches cluster records for up to 5s even when CoreDNS serves TTL-0 records, and toggling this on an existing cluster recreates all node pools. | `bool` | `false` | no |
+| <a name="input_enable_upgrade_notifications"></a> [enable\_upgrade\_notifications](#input\_enable\_upgrade\_notifications) | Publish GKE upgrade notifications to a Pub/Sub topic and let orchestratord's service account subscribe to them and read node pool state. Required for the operator module's enable\_node\_upgrade\_rollout\_trigger. | `bool` | `true` | no |
 | <a name="input_gce_persistent_disk_csi_driver_enabled"></a> [gce\_persistent\_disk\_csi\_driver\_enabled](#input\_gce\_persistent\_disk\_csi\_driver\_enabled) | Whether to enable the GCE persistent disk CSI driver | `bool` | `true` | no |
 | <a name="input_horizontal_pod_autoscaling_disabled"></a> [horizontal\_pod\_autoscaling\_disabled](#input\_horizontal\_pod\_autoscaling\_disabled) | Whether to disable horizontal pod autoscaling | `bool` | `false` | no |
 | <a name="input_http_load_balancing_disabled"></a> [http\_load\_balancing\_disabled](#input\_http\_load\_balancing\_disabled) | Whether to disable HTTP load balancing | `bool` | `false` | no |
@@ -58,4 +63,5 @@ No modules.
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | The name of the GKE cluster |
 | <a name="output_cluster_private_endpoint"></a> [cluster\_private\_endpoint](#output\_cluster\_private\_endpoint) | The private endpoint of the GKE cluster (used by nodes and VPC resources) |
 | <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | The email of the GKE service account |
+| <a name="output_upgrade_notification_subscription"></a> [upgrade\_notification\_subscription](#output\_upgrade\_notification\_subscription) | The Pub/Sub subscription (projects/{project}/subscriptions/{name}) on which orchestratord receives GKE upgrade notifications. Null unless enable\_upgrade\_notifications is set. |
 | <a name="output_workload_identity_sa_email"></a> [workload\_identity\_sa\_email](#output\_workload\_identity\_sa\_email) | The email of the Workload Identity service account |

--- a/gcp/modules/gke/main.tf
+++ b/gcp/modules/gke/main.tf
@@ -198,6 +198,6 @@ resource "google_service_account_iam_binding" "workload_identity" {
   service_account_id = google_service_account.workload_identity_sa.name
   role               = "roles/iam.workloadIdentityUser"
   members = [
-    "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/orchestratord]"
+    "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/${var.orchestratord_service_account_name}]"
   ]
 }

--- a/gcp/modules/gke/main.tf
+++ b/gcp/modules/gke/main.tf
@@ -109,6 +109,68 @@ resource "google_container_cluster" "primary" {
   # https://docs.cloud.google.com/kubernetes-engine/docs/how-to/user-managed-firewall-rules#disable-in-new-cluster
   disable_l4_lb_firewall_reconciliation = true
   enable_l4_ilb_subsetting              = true
+
+  # Publish upgrade notifications to Pub/Sub so that orchestratord can react
+  # to node pool upgrades (see the operator module's
+  # enable_node_upgrade_rollout_trigger).
+  dynamic "notification_config" {
+    for_each = var.enable_upgrade_notifications ? [1] : []
+    content {
+      pubsub {
+        enabled = true
+        topic   = google_pubsub_topic.upgrade_notifications[0].id
+        filter {
+          event_type = ["UPGRADE_EVENT"]
+        }
+      }
+    }
+  }
+}
+
+resource "google_pubsub_topic" "upgrade_notifications" {
+  count = var.enable_upgrade_notifications ? 1 : 0
+
+  project = var.project_id
+  name    = "${var.prefix}-gke-upgrade-notifications"
+  labels  = var.labels
+}
+
+resource "google_pubsub_subscription" "orchestratord_upgrade_notifications" {
+  count = var.enable_upgrade_notifications ? 1 : 0
+
+  project = var.project_id
+  name    = "${var.prefix}-orchestratord-upgrade-notifications"
+  topic   = google_pubsub_topic.upgrade_notifications[0].id
+  labels  = var.labels
+
+  # Notifications older than this are only useful for arming faster than
+  # orchestratord's periodic poll of the GKE API, which also catches any
+  # upgrades whose notifications expired here.
+  message_retention_duration = "86400s"
+
+  # Never expire the subscription due to inactivity: upgrades can be rare.
+  expiration_policy {
+    ttl = ""
+  }
+}
+
+resource "google_pubsub_subscription_iam_member" "orchestratord_upgrade_notifications_subscriber" {
+  count = var.enable_upgrade_notifications ? 1 : 0
+
+  project      = var.project_id
+  subscription = google_pubsub_subscription.orchestratord_upgrade_notifications[0].name
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:${google_service_account.workload_identity_sa.email}"
+}
+
+# Lets orchestratord read node pool state (blue-green upgrade phase) to
+# decide when it is safe to trigger rollouts.
+resource "google_project_iam_member" "orchestratord_cluster_viewer" {
+  count = var.enable_upgrade_notifications ? 1 : 0
+
+  project = var.project_id
+  role    = "roles/container.clusterViewer"
+  member  = "serviceAccount:${google_service_account.workload_identity_sa.email}"
 }
 
 # Firewall rule to allow traffic to nodes on port 8001 for conversion webhooks.

--- a/gcp/modules/gke/outputs.tf
+++ b/gcp/modules/gke/outputs.tf
@@ -33,3 +33,8 @@ output "workload_identity_sa_email" {
   description = "The email of the Workload Identity service account"
   value       = google_service_account.workload_identity_sa.email
 }
+
+output "upgrade_notification_subscription" {
+  description = "The Pub/Sub subscription (projects/{project}/subscriptions/{name}) on which orchestratord receives GKE upgrade notifications. Null unless enable_upgrade_notifications is set."
+  value       = var.enable_upgrade_notifications ? google_pubsub_subscription.orchestratord_upgrade_notifications[0].id : null
+}

--- a/gcp/modules/gke/variables.tf
+++ b/gcp/modules/gke/variables.tf
@@ -136,3 +136,10 @@ variable "k8s_apiserver_authorized_networks" {
   }]
   nullable = false
 }
+
+variable "enable_upgrade_notifications" {
+  description = "Publish GKE upgrade notifications to a Pub/Sub topic and let orchestratord's service account subscribe to them and read node pool state. Required for the operator module's enable_node_upgrade_rollout_trigger."
+  type        = bool
+  default     = true
+  nullable    = false
+}

--- a/gcp/modules/gke/variables.tf
+++ b/gcp/modules/gke/variables.tf
@@ -36,6 +36,13 @@ variable "namespace" {
   nullable    = false
 }
 
+variable "orchestratord_service_account_name" {
+  description = "The name of the operator's Kubernetes service account bound to the workload identity service account. Must match the Materialize operator chart's serviceAccount.name value (the operator module leaves this at the chart default, \"orchestratord\")."
+  type        = string
+  default     = "orchestratord"
+  nullable    = false
+}
+
 variable "networking_mode" {
   description = "The networking mode for the GKE cluster"
   type        = string

--- a/gcp/modules/nodepool/README.md
+++ b/gcp/modules/nodepool/README.md
@@ -54,7 +54,7 @@ No modules.
 | <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | The email of the service account to use for the nodes | `string` | n/a | yes |
 | <a name="input_swap_enabled"></a> [swap\_enabled](#input\_swap\_enabled) | Whether to enable swap on the local NVMe disks. | `bool` | `true` | no |
 | <a name="input_upgrade_node_pool_soak_duration"></a> [upgrade\_node\_pool\_soak\_duration](#input\_upgrade\_node\_pool\_soak\_duration) | How long GKE keeps the drained blue pool around before deleting it during a node pool upgrade, as a duration in seconds (e.g. "3600s"). When null, GKE's default is used. | `string` | `null` | no |
-| <a name="input_upgrade_wait_for_drain_duration"></a> [upgrade\_wait\_for\_drain\_duration](#input\_upgrade\_wait\_for\_drain\_duration) | How long GKE waits after cordoning the blue pool before draining it during an (autoscaled blue-green) node pool upgrade. This is the window in which workloads can move to the replacement nodes gracefully. Between 0 and 7 days, as a duration in seconds (e.g. "604800s"). | `string` | `"604800s"` | no |
+| <a name="input_upgrade_wait_for_drain_duration"></a> [upgrade\_wait\_for\_drain\_duration](#input\_upgrade\_wait\_for\_drain\_duration) | How long GKE waits after cordoning the blue pool before draining it during an (autoscaled blue-green) node pool upgrade. This is the window in which workloads can move to the replacement nodes gracefully. Between 0 and 7 days, as a duration in seconds (e.g. "604800s"). | `string` | `"259200s"` | no |
 | <a name="input_workload_metadata_mode"></a> [workload\_metadata\_mode](#input\_workload\_metadata\_mode) | Mode for workload metadata configuration | `string` | `"GKE_METADATA"` | no |
 
 ## Outputs

--- a/gcp/modules/nodepool/README.md
+++ b/gcp/modules/nodepool/README.md
@@ -4,13 +4,14 @@
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.22, < 8 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 7.22, < 8 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0, < 2.39.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_google"></a> [google](#provider\_google) | >= 7.22, < 8 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 7.22, < 8 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10.0, < 2.39.0 |
 
 ## Modules
@@ -21,7 +22,7 @@ No modules.
 
 | Name | Type |
 | ---- | ---- |
-| [google_container_node_pool.primary_nodes](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool) | resource |
+| [google-beta_google_container_node_pool.primary_nodes](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_node_pool) | resource |
 | [kubernetes_cluster_role.disk_setup](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role_binding.disk_setup](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_daemonset.disk_setup](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/daemonset) | resource |
@@ -52,6 +53,8 @@ No modules.
 | <a name="input_region"></a> [region](#input\_region) | The region where the cluster is located | `string` | n/a | yes |
 | <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | The email of the service account to use for the nodes | `string` | n/a | yes |
 | <a name="input_swap_enabled"></a> [swap\_enabled](#input\_swap\_enabled) | Whether to enable swap on the local NVMe disks. | `bool` | `true` | no |
+| <a name="input_upgrade_node_pool_soak_duration"></a> [upgrade\_node\_pool\_soak\_duration](#input\_upgrade\_node\_pool\_soak\_duration) | How long GKE keeps the drained blue pool around before deleting it during a node pool upgrade, as a duration in seconds (e.g. "3600s"). When null, GKE's default is used. | `string` | `null` | no |
+| <a name="input_upgrade_wait_for_drain_duration"></a> [upgrade\_wait\_for\_drain\_duration](#input\_upgrade\_wait\_for\_drain\_duration) | How long GKE waits after cordoning the blue pool before draining it during an (autoscaled blue-green) node pool upgrade. This is the window in which workloads can move to the replacement nodes gracefully. Between 0 and 7 days, as a duration in seconds (e.g. "604800s"). | `string` | `"604800s"` | no |
 | <a name="input_workload_metadata_mode"></a> [workload\_metadata\_mode](#input\_workload\_metadata\_mode) | Mode for workload metadata configuration | `string` | `"GKE_METADATA"` | no |
 
 ## Outputs

--- a/gcp/modules/nodepool/main.tf
+++ b/gcp/modules/nodepool/main.tf
@@ -36,7 +36,8 @@ locals {
 }
 
 resource "google_container_node_pool" "primary_nodes" {
-  provider = google
+  # google-beta is required for upgrade_settings.blue_green_settings.autoscaled_rollout_policy.
+  provider = google-beta
 
   name     = "${var.prefix}-nodepool"
   location = var.region
@@ -46,6 +47,26 @@ resource "google_container_node_pool" "primary_nodes" {
   autoscaling {
     min_node_count = var.min_nodes
     max_node_count = var.max_nodes
+  }
+
+  # GKE upgrades node pools automatically (e.g. to roll out new node images)
+  # and this cannot be disabled, only delayed. Autoscaled blue-green upgrades
+  # create the replacement (green) pool empty, cordon all of the original
+  # (blue) nodes, and then wait for up to wait_for_drain_duration before
+  # draining anything, with the cluster autoscaler scaling up the green pool
+  # as pods move over. That wait is the window in which orchestratord
+  # gracefully rolls Materialize instances onto the green nodes (see the
+  # operator module's enable_node_upgrade_rollout_trigger).
+  #
+  # Requires a GKE control plane version of 1.34.0-gke.2201000 or later.
+  upgrade_settings {
+    strategy = "BLUE_GREEN"
+    blue_green_settings {
+      autoscaled_rollout_policy {
+        wait_for_drain_duration = var.upgrade_wait_for_drain_duration
+      }
+      node_pool_soak_duration = var.upgrade_node_pool_soak_duration
+    }
   }
 
   network_config {

--- a/gcp/modules/nodepool/variables.tf
+++ b/gcp/modules/nodepool/variables.tf
@@ -154,3 +154,16 @@ variable "pause_container_resource_config" {
   }
   nullable = false
 }
+
+variable "upgrade_wait_for_drain_duration" {
+  description = "How long GKE waits after cordoning the blue pool before draining it during an (autoscaled blue-green) node pool upgrade. This is the window in which workloads can move to the replacement nodes gracefully. Between 0 and 7 days, as a duration in seconds (e.g. \"604800s\")."
+  type        = string
+  default     = "604800s" # 7 days, the maximum
+  nullable    = false
+}
+
+variable "upgrade_node_pool_soak_duration" {
+  description = "How long GKE keeps the drained blue pool around before deleting it during a node pool upgrade, as a duration in seconds (e.g. \"3600s\"). When null, GKE's default is used."
+  type        = string
+  default     = null
+}

--- a/gcp/modules/nodepool/variables.tf
+++ b/gcp/modules/nodepool/variables.tf
@@ -158,7 +158,7 @@ variable "pause_container_resource_config" {
 variable "upgrade_wait_for_drain_duration" {
   description = "How long GKE waits after cordoning the blue pool before draining it during an (autoscaled blue-green) node pool upgrade. This is the window in which workloads can move to the replacement nodes gracefully. Between 0 and 7 days, as a duration in seconds (e.g. \"604800s\")."
   type        = string
-  default     = "604800s" # 7 days, the maximum
+  default     = "259200s" # 3 days, the GKE default (maximum is 7 days)
   nullable    = false
 }
 

--- a/gcp/modules/nodepool/versions.tf
+++ b/gcp/modules/nodepool/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 7.22, < 8"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 7.22, < 8"
+    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = ">= 2.10.0, < 2.39.0"

--- a/gcp/modules/operator/README.md
+++ b/gcp/modules/operator/README.md
@@ -29,14 +29,18 @@ No modules.
 | [kubernetes_network_policy_v1.allow_api_server_egress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy_v1) | resource |
 | [kubernetes_network_policy_v1.allow_api_server_ingress_to_conversion_webhook](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy_v1) | resource |
 | [kubernetes_network_policy_v1.allow_kube_system_egress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy_v1) | resource |
+| [kubernetes_network_policy_v1.allow_metadata_server_egress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy_v1) | resource |
 | [kubernetes_network_policy_v1.allow_monitoring_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy_v1) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | The location (region or zone) of the GKE cluster. Required when enable\_node\_upgrade\_rollout\_trigger is set. | `string` | `null` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the GKE cluster. Required when enable\_node\_upgrade\_rollout\_trigger is set. | `string` | `null` | no |
 | <a name="input_enable_license_key_checks"></a> [enable\_license\_key\_checks](#input\_enable\_license\_key\_checks) | Enable license key checks. | `bool` | `true` | no |
 | <a name="input_enable_network_policies"></a> [enable\_network\_policies](#input\_enable\_network\_policies) | Enable network policies for the operator namespace | `bool` | `true` | no |
+| <a name="input_enable_node_upgrade_rollout_trigger"></a> [enable\_node\_upgrade\_rollout\_trigger](#input\_enable\_node\_upgrade\_rollout\_trigger) | Have orchestratord trigger rollouts of Materialize instances when GKE upgrades the node pools they run on, moving their pods to the replacement nodes gracefully instead of letting GKE evict them. Requires install\_v1\_crd, the gke module's enable\_upgrade\_notifications, and node pools using the (autoscaled) blue-green upgrade strategy. | `bool` | `false` | no |
 | <a name="input_helm_chart"></a> [helm\_chart](#input\_helm\_chart) | Chart name from repository or local path to chart. For local charts, set the path to the chart directory. | `string` | `"materialize-operator"` | no |
 | <a name="input_helm_repository"></a> [helm\_repository](#input\_helm\_repository) | Repository URL for the Materialize operator Helm chart. Leave empty if using local chart. | `string` | `"https://materializeinc.github.io/materialize/"` | no |
 | <a name="input_helm_values"></a> [helm\_values](#input\_helm\_values) | Values to pass to the Helm chart | `any` | `{}` | no |
@@ -48,8 +52,11 @@ No modules.
 | <a name="input_metrics_server_version"></a> [metrics\_server\_version](#input\_metrics\_server\_version) | Version of metrics-server to install | `string` | `"3.12.2"` | no |
 | <a name="input_monitoring_namespace"></a> [monitoring\_namespace](#input\_monitoring\_namespace) | Namespace for monitoring resources | `string` | `"monitoring"` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for all resource names (replaces separate namespace and environment variables) | `string` | n/a | yes |
+| <a name="input_node_upgrade_notification_subscription"></a> [node\_upgrade\_notification\_subscription](#input\_node\_upgrade\_notification\_subscription) | The Pub/Sub subscription receiving GKE upgrade notifications (the gke module's upgrade\_notification\_subscription output). Required when enable\_node\_upgrade\_rollout\_trigger is set. | `string` | `null` | no |
+| <a name="input_node_upgrade_watched_node_pools"></a> [node\_upgrade\_watched\_node\_pools](#input\_node\_upgrade\_watched\_node\_pools) | The node pools whose upgrades trigger Materialize rollouts. An empty list watches all node pools. | `list(string)` | `[]` | no |
 | <a name="input_operator_namespace"></a> [operator\_namespace](#input\_operator\_namespace) | Namespace for the Materialize operator | `string` | `"materialize"` | no |
 | <a name="input_operator_node_selector"></a> [operator\_node\_selector](#input\_operator\_node\_selector) | Node selector for operator pods and metrics-server. | `map(string)` | `{}` | no |
+| <a name="input_operator_service_account_annotations"></a> [operator\_service\_account\_annotations](#input\_operator\_service\_account\_annotations) | Annotations to add to the operator's Kubernetes service account, e.g. iam.gke.io/gcp-service-account to link it to a GCP service account via workload identity (required for enable\_node\_upgrade\_rollout\_trigger). | `map(string)` | `{}` | no |
 | <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | Version of the Materialize operator to install | `string` | `"v26.34.1"` | no |
 | <a name="input_orchestratord_version"></a> [orchestratord\_version](#input\_orchestratord\_version) | Version of the Materialize orchestrator to install | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region/Zone for the operator Helm values. | `string` | n/a | yes |

--- a/gcp/modules/operator/main.tf
+++ b/gcp/modules/operator/main.tf
@@ -58,6 +58,13 @@ locals {
         providers = {
           gcp = {
             enabled = true
+            nodeUpgradeRolloutTrigger = {
+              enabled                  = var.enable_node_upgrade_rollout_trigger
+              notificationSubscription = var.node_upgrade_notification_subscription
+              clusterName              = var.cluster_name
+              clusterLocation          = var.cluster_location
+              watchedNodePools         = var.node_upgrade_watched_node_pools
+            }
           }
         }
       }
@@ -67,6 +74,10 @@ locals {
       # Node selector and tolerations for operator pods
       nodeSelector = var.operator_node_selector
       tolerations  = var.tolerations
+    }
+
+    serviceAccount = {
+      annotations = var.operator_service_account_annotations
     }
 
     # Materialize workload configurations
@@ -102,6 +113,18 @@ resource "helm_release" "materialize_operator" {
   ]
 
   depends_on = [kubernetes_namespace.materialize]
+
+  lifecycle {
+    precondition {
+      condition = !var.enable_node_upgrade_rollout_trigger || (
+        var.node_upgrade_notification_subscription != null
+        && var.cluster_name != null
+        && var.cluster_location != null
+        && var.install_v1_crd
+      )
+      error_message = "enable_node_upgrade_rollout_trigger requires node_upgrade_notification_subscription, cluster_name, cluster_location, and install_v1_crd."
+    }
+  }
 }
 
 
@@ -156,6 +179,53 @@ resource "kubernetes_network_policy_v1" "allow_api_server_egress" {
       ports {
         protocol = "TCP"
         port     = 443
+      }
+    }
+  }
+}
+
+# Allow egress to the GKE metadata server so orchestratord can obtain
+# workload identity credentials for the node upgrade rollout trigger.
+# Credential requests go to 169.254.169.254:80 (plain HTTP); on Dataplane V2
+# the gke-metadata-server also answers on 169.254.169.252:988, and Cilium can
+# enforce policy on the post-DNAT destination, so allow both.
+resource "kubernetes_network_policy_v1" "allow_metadata_server_egress" {
+  count = var.enable_network_policies && var.enable_node_upgrade_rollout_trigger ? 1 : 0
+
+  metadata {
+    name      = "allow-metadata-server-egress"
+    namespace = kubernetes_namespace.materialize.metadata[0].name
+  }
+
+  spec {
+    pod_selector {
+      match_labels = {
+        "app.kubernetes.io/name" = "materialize-operator"
+      }
+    }
+    policy_types = ["Egress"]
+
+    egress {
+      to {
+        ip_block {
+          cidr = "169.254.169.254/32"
+        }
+      }
+      ports {
+        protocol = "TCP"
+        port     = 80
+      }
+    }
+
+    egress {
+      to {
+        ip_block {
+          cidr = "169.254.169.252/32"
+        }
+      }
+      ports {
+        protocol = "TCP"
+        port     = 988
       }
     }
   }

--- a/gcp/modules/operator/variables.tf
+++ b/gcp/modules/operator/variables.tf
@@ -155,3 +155,42 @@ variable "enable_network_policies" {
   default     = true
   nullable    = false
 }
+
+variable "enable_node_upgrade_rollout_trigger" {
+  description = "Have orchestratord trigger rollouts of Materialize instances when GKE upgrades the node pools they run on, moving their pods to the replacement nodes gracefully instead of letting GKE evict them. Requires install_v1_crd, the gke module's enable_upgrade_notifications, and node pools using the (autoscaled) blue-green upgrade strategy."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "node_upgrade_notification_subscription" {
+  description = "The Pub/Sub subscription receiving GKE upgrade notifications (the gke module's upgrade_notification_subscription output). Required when enable_node_upgrade_rollout_trigger is set."
+  type        = string
+  default     = null
+}
+
+variable "cluster_name" {
+  description = "The name of the GKE cluster. Required when enable_node_upgrade_rollout_trigger is set."
+  type        = string
+  default     = null
+}
+
+variable "cluster_location" {
+  description = "The location (region or zone) of the GKE cluster. Required when enable_node_upgrade_rollout_trigger is set."
+  type        = string
+  default     = null
+}
+
+variable "node_upgrade_watched_node_pools" {
+  description = "The node pools whose upgrades trigger Materialize rollouts. An empty list watches all node pools."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+variable "operator_service_account_annotations" {
+  description = "Annotations to add to the operator's Kubernetes service account, e.g. iam.gke.io/gcp-service-account to link it to a GCP service account via workload identity (required for enable_node_upgrade_rollout_trigger)."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}


### PR DESCRIPTION
## Motivation

GKE automatically upgrades node pools (this cannot be disabled), evicting Materialize pods and causing outages. Part of the [GCP nodegroup updates without major downtime](https://linear.app/materializeinc/project/gcp-nodegroup-updates-without-major-downtime-caba69cf4871/overview) Linear project, together with MaterializeInc/materialize#37807 (the orchestratord watcher).

Note that this will not take effect until we ship an orchestratord version that supports this.

## Changes

- **nodepool**: always use the autoscaled blue-green upgrade strategy — GKE creates the replacement (green) pool empty, cordons all original (blue) nodes, then waits `upgrade_wait_for_drain_duration` (default: the 3-day GKE default) before draining, with the cluster autoscaler scaling up the green pool as pods move. That wait is the window in which orchestratord rolls Materialize instances over gracefully. Requires the `google-beta` provider (the autoscaled rollout policy isn't in the GA provider) and a GKE control plane of 1.34.0-gke.2201000+ (STABLE channel is on 1.34.x).
- **gke**: publish `UpgradeEvent` cluster notifications to a new Pub/Sub topic (`enable_upgrade_notifications`, default on), create orchestratord's subscription, and grant its workload identity service account `roles/pubsub.subscriber` on it plus `roles/container.clusterViewer` for reading node pool upgrade state.
- **operator**: new `enable_node_upgrade_rollout_trigger` flag wiring the chart's `operator.cloudProvider.providers.gcp.nodeUpgradeRolloutTrigger` values (subscription, cluster name/location, watched node pools) plus operator service account annotations for workload identity. Also adds a network policy allowing operator egress to the GKE metadata server (`169.254.169.254:80`, plus `169.254.169.252:988` for the Dataplane V2 post-DNAT destination): workload identity credentials come over plain HTTP, which the existing egress policies (kube-system, 443, environmentd) blocked, leaving the watcher unable to authenticate ("no available authentication method found").
- **examples** (simple, enterprise): trigger enabled by default, watching the materialize node pool. The migration example gains the `google-beta` provider for the nodepool module (blue-green settings apply in-place, non-disruptively).

## Testing

Verified end-to-end on a test-harness run (us-east4, image `devel-b0b2754e` + local chart from the companion PR): watcher armed on the `UpgradeEvent`, polled until `WAITING_TO_DRAIN_BLUE_POOL` with the blue node cordoned, stamped `materialize.cloud/force-rollout` on the Materialize CR, and the new generation came up on the autoscaled green node with no evictions (`WaitUntilReady`).

## Notes for reviewer

- The trigger stays inert until an operator/chart release containing the watcher ships (examples pin `operator_version = v26.33.0`); the new helm values are ignored by older charts.
- The rollout only moves environmentd/clusterd; balancerd/console (and other pods) stay on the cordoned blue nodes until GKE's post-wait drain. Follow-up work (PDBs for envd/clusterd, `DISRUPTION_EVENT` handling) is planned separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
