### PR TITLE
ci: create releases from PR labels after merge

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,7 +5,8 @@
 ```
 pr.yml (pull_request)
   └── lint.yml
-  └── ci-success (gates on lint)
+  └── version-label (requires a label determining the version bump)
+  └── ci-success (gates on all above)
 
 merge_queue.yml (merge_group)
   └── lint.yml
@@ -13,6 +14,9 @@ merge_queue.yml (merge_group)
   └── test-gcp.yml
   └── test-azure.yml
   └── ci-success (gates on all above)
+
+tag.yml (push to main)
+  └── creates the tag and GitHub release, bump level from PR labels
 ```
 
 ## Merge Queue Integration
@@ -21,19 +25,39 @@ Infrastructure tests **integrate with GitHub's merge queue** to ensure only appr
 
 ### How It Works
 
-1. **Create PR** - `pr.yml` runs lint checks, `ci-success` passes when lint passes
+1. **Create PR** - `pr.yml` runs lint checks and requires a version label, `ci-success` passes when both pass
 2. **Get approval** - PR enters merge queue automatically
 3. **Tests run** - `merge_queue.yml` runs full infrastructure tests (AWS, GCP, Azure)
 4. **Auto-merge** - When `ci-success` passes, code merges to `main`
-5. **Manual trigger** - Use `gh workflow run test-<cloud>.yml` if needed
+5. **Release** - `tag.yml` creates the tag and GitHub release, see [Releases](#releases)
+6. **Manual trigger** - Use `gh workflow run test-<cloud>.yml` if needed
 
 ### PR vs Merge Queue Behavior
 
 | Event | Workflow | What Runs | ci-success gates on |
 |-------|----------|-----------|---------------------|
-| `pull_request` | `pr.yml` | Lint only | Lint |
+| `pull_request` | `pr.yml` | Lint + version label check | Lint + version label |
 | `merge_group` | `merge_queue.yml` | Lint + all cloud tests | Lint + AWS + GCP + Azure |
+| `push` to `main` | `tag.yml` | Tag and GitHub release | N/A |
 | `workflow_dispatch` | `test-*.yml` | Individual cloud test | N/A |
+
+### Releases
+
+`tag.yml` runs on every push to `main` and creates the tag and GitHub release
+automatically. The version bump is determined by the labels of the PRs merged
+since the latest release, the highest level wins:
+
+| Label | Release |
+|-------|---------|
+| `breaking-change` | major |
+| `enhancement` | minor |
+| `bug`, `dependencies`, `documentation`, `github_actions` | patch |
+| `ignore-for-release` | none, ships with the next labeled PR |
+
+The `version-label` job in `pr.yml` blocks PRs that carry none of these
+labels. Merging happens through the merge queue, so a release is only created
+after the infrastructure tests have passed. Direct pushes to `main` are not
+released automatically, their changes ship with the next labeled PR.
 
 ### What Gets Tested (Merge Queue Only)
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,23 +3,54 @@ name: PR
 on:
   pull_request:
     branches: [main]
+    # labeled and unlabeled are included so the version-label check reruns
+    # when labels change.
+    types: [opened, reopened, synchronize, labeled, unlabeled]
 
 jobs:
   lint:
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
+  version-label:
+    name: Version Label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a version label
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          matches=$(echo "$LABELS" | jq '[.[] | select(
+            . == "breaking-change" or
+            . == "enhancement" or
+            . == "bug" or
+            . == "dependencies" or
+            . == "documentation" or
+            . == "github_actions" or
+            . == "ignore-for-release"
+          )] | length')
+          if [ "$matches" -eq 0 ]; then
+            echo "This PR has no label determining the version bump of the release created after merging. Add at least one of:"
+            echo "  breaking-change: major release"
+            echo "  enhancement: minor release"
+            echo "  bug, dependencies, documentation, github_actions: patch release"
+            echo "  ignore-for-release: no release, ships with the next labeled PR"
+            exit 1
+          fi
+          echo "Version labels found: $LABELS"
+
   ci-success:
     runs-on: ubuntu-latest
     needs:
       - lint
+      - version-label
     if: always()
     steps:
       - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3.0.3
-      - name: Verify lint passed
+      - name: Verify all checks passed
         if: env.WORKFLOW_CONCLUSION != 'success'
         run: |
-          echo "Lint checks failed: ${{ env.WORKFLOW_CONCLUSION }}"
+          echo "Checks failed: ${{ env.WORKFLOW_CONCLUSION }}"
           exit 1
       - name: Success
         run: echo "All PR checks passed"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -23,6 +23,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -e \
           latest=$(gh api --paginate "repos/$GITHUB_REPOSITORY/tags" --jq '.[].name' \
             | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
           echo "Latest release: $latest"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,69 @@
+name: Tag
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+# Serialize runs so concurrent pushes cannot race on computing the next
+# version. A superseded pending run is skipped, its commits are picked up by
+# the newest run since every run considers everything since the latest tag.
+concurrency:
+  group: tag-main
+
+jobs:
+  tag:
+    name: Tag and Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create release for merged changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          latest=$(gh api --paginate "repos/$GITHUB_REPOSITORY/tags" --jq '.[].name' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
+          echo "Latest release: $latest"
+
+          # Everything merged since the latest release is part of this
+          # release, not just the commits of this push.
+          prs=$(gh api "repos/$GITHUB_REPOSITORY/compare/$latest...$GITHUB_SHA" --jq '.commits[].sha' \
+            | while read -r sha; do
+                gh api "repos/$GITHUB_REPOSITORY/commits/$sha/pulls" \
+                  --jq '.[] | select(.merged_at != null) | .number'
+              done | sort -un)
+
+          # The highest bump level across all merged PRs wins. Commits without
+          # a PR or without version labels are released with the next labeled
+          # PR.
+          bump=""
+          for pr in $prs; do
+            while IFS= read -r label; do
+              case "$label" in
+                breaking-change) bump=major ;;
+                enhancement) if [ "$bump" != major ]; then bump=minor; fi ;;
+                bug|dependencies|documentation|github_actions) if [ -z "$bump" ]; then bump=patch; fi ;;
+              esac
+            done < <(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr" --jq '.labels[].name')
+          done
+
+          if [ -z "$bump" ]; then
+            echo "No version label on any PR merged since $latest, not creating a release"
+            exit 0
+          fi
+
+          IFS=. read -r major minor patch <<< "${latest#v}"
+          case "$bump" in
+            major) version="v$((major + 1)).0.0" ;;
+            minor) version="v$major.$((minor + 1)).0" ;;
+            patch) version="v$major.$minor.$((patch + 1))" ;;
+          esac
+
+          echo "Creating release $version ($bump bump from $latest)"
+          gh release create "$version" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "$version" \
+            --generate-notes

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   ],
   "rangeStrategy": "widen",
   "labels": [
-    "regenerate-docs"
+    "regenerate-docs",
+    "dependencies"
   ]
 }


### PR DESCRIPTION
Motivation: https://materializeinc.slack.com/archives/C07PN7KSB0T/p1784207503.911529

The helm-chart publish pipeline in MaterializeInc/materialize currently pushes version bumps directly to `main` and blindly tags a patch release, without tests and regardless of what else is sitting on `main` unreleased. That can sweep breaking changes into a patch version. This PR moves tagging into this repository's CI instead:

* `pr.yml` gains a blocking `version-label` job that requires every PR to carry at least one label determining the version bump of the release created after merging: `breaking-change` (major), `enhancement` (minor), `bug`/`dependencies`/`documentation`/`github_actions` (patch), or `ignore-for-release` (no release). It feeds the existing required `ci-success` check, so no ruleset changes are needed.
* A new `tag.yml` runs on every push to `main`, computes the bump from the labels of the PRs merged since the latest tag (highest level wins), and creates the tag and GitHub release. Merges only happen through the merge queue, so the release is created after the infrastructure tests passed. A merge queue batch containing several PRs creates a single release.
* `renovate.json` additionally labels Renovate PRs with `dependencies` so they pass the new check and default to patch releases. Dependabot already labels its PRs with `dependencies` on its own. Humans can escalate a dependency PR to `breaking-change` before merging, like #296.

Notes:

* Direct pushes to `main` (bypassing the merge queue) are not tagged, their changes ship with the next labeled PR. That also makes the transition safe: the current publish pipeline's direct pushes have no associated PR, so `tag.yml` skips them and the pipeline's own tagging keeps working until a follow-up PR in MaterializeInc/materialize switches it to opening a labeled PR here.
* The currently unreleased #315 and #316 carry no labels, so merging this PR does not create a release. They will be part of the next labeled release.
* Manually pushed tags (e.g. for coordinated major releases) still work, the existing `release.yml` creates the GitHub release for those and `tag.yml` picks up the new tag as the baseline afterwards.
* The repository setting "Allow auto-merge" is currently disabled. Enabling it would let the publish pipeline mark its bump PRs as "merge when ready" so they merge and release right after a human approves them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)