### PR TITLE
feat(examples): single materialize_version driving operator + environmentd

### DIFF
--- a/aws/examples/enterprise/main.tf
+++ b/aws/examples/enterprise/main.tf
@@ -309,6 +309,8 @@ module "self_signed_cluster_issuer" {
 module "operator" {
   source = "../../modules/operator"
 
+  operator_version = var.materialize_version
+
   name_prefix    = var.name_prefix
   aws_region     = var.aws_region
   aws_account_id = data.aws_caller_identity.current.account_id
@@ -476,6 +478,7 @@ module "storage" {
 # 9. Setup Materialize instance
 module "materialize_instance" {
   source               = "../../../kubernetes/modules/materialize-instance"
+  environmentd_version = var.materialize_version
   instance_name        = local.materialize_instance_name
   instance_namespace   = local.materialize_instance_namespace
   metadata_backend_url = local.metadata_backend_url

--- a/aws/examples/enterprise/variables.tf
+++ b/aws/examples/enterprise/variables.tf
@@ -153,3 +153,9 @@ variable "upstream_oidc_providers" {
   nullable  = false
   sensitive = true
 }
+
+variable "materialize_version" {
+  description = "Materialize release for both the operator Helm chart and environmentd, which must not drift. Null uses each module's default."
+  type        = string
+  default     = null
+}

--- a/aws/examples/simple/main.tf
+++ b/aws/examples/simple/main.tf
@@ -333,6 +333,8 @@ module "self_signed_cluster_issuer" {
 module "operator" {
   source = "../../modules/operator"
 
+  operator_version = var.materialize_version
+
   name_prefix    = var.name_prefix
   aws_region     = var.aws_region
   aws_account_id = data.aws_caller_identity.current.account_id
@@ -427,6 +429,7 @@ module "storage" {
 # 9. Setup Materialize instance
 module "materialize_instance" {
   source               = "../../../kubernetes/modules/materialize-instance"
+  environmentd_version = var.materialize_version
   instance_name        = local.materialize_instance_name
   instance_namespace   = local.materialize_instance_namespace
   metadata_backend_url = local.metadata_backend_url

--- a/aws/examples/simple/variables.tf
+++ b/aws/examples/simple/variables.tf
@@ -72,3 +72,9 @@ variable "enable_observability" {
   type        = bool
   default     = false
 }
+
+variable "materialize_version" {
+  description = "Materialize release for both the operator Helm chart and environmentd, which must not drift. Null uses each module's default."
+  type        = string
+  default     = null
+}

--- a/azure/examples/enterprise/main.tf
+++ b/azure/examples/enterprise/main.tf
@@ -401,6 +401,8 @@ module "self_signed_cluster_issuer" {
 module "operator" {
   source = "../../modules/operator"
 
+  operator_version = var.materialize_version
+
   name_prefix = var.name_prefix
   location    = var.location
 
@@ -463,6 +465,7 @@ module "grafana" {
 
 module "materialize_instance" {
   source               = "../../../kubernetes/modules/materialize-instance"
+  environmentd_version = var.materialize_version
   instance_name        = local.materialize_instance_name
   instance_namespace   = local.materialize_instance_namespace
   metadata_backend_url = local.metadata_backend_url

--- a/azure/examples/enterprise/variables.tf
+++ b/azure/examples/enterprise/variables.tf
@@ -163,3 +163,9 @@ variable "upstream_oidc_providers" {
   nullable  = false
   sensitive = true
 }
+
+variable "materialize_version" {
+  description = "Materialize release for both the operator Helm chart and environmentd, which must not drift. Null uses each module's default."
+  type        = string
+  default     = null
+}

--- a/azure/examples/simple/main.tf
+++ b/azure/examples/simple/main.tf
@@ -322,6 +322,8 @@ module "self_signed_cluster_issuer" {
 module "operator" {
   source = "../../modules/operator"
 
+  operator_version = var.materialize_version
+
   name_prefix = var.name_prefix
   location    = var.location
 
@@ -386,6 +388,7 @@ module "grafana" {
 
 module "materialize_instance" {
   source                  = "../../../kubernetes/modules/materialize-instance"
+  environmentd_version    = var.materialize_version
   instance_name           = local.materialize_instance_name
   instance_namespace      = local.materialize_instance_namespace
   metadata_backend_url    = local.metadata_backend_url

--- a/azure/examples/simple/variables.tf
+++ b/azure/examples/simple/variables.tf
@@ -86,3 +86,9 @@ variable "enable_observability" {
   type        = bool
   default     = false
 }
+
+variable "materialize_version" {
+  description = "Materialize release for both the operator Helm chart and environmentd, which must not drift. Null uses each module's default."
+  type        = string
+  default     = null
+}

--- a/gcp/examples/enterprise/main.tf
+++ b/gcp/examples/enterprise/main.tf
@@ -377,6 +377,8 @@ module "self_signed_cluster_issuer" {
 module "operator" {
   source = "../../modules/operator"
 
+  operator_version = var.materialize_version
+
   name_prefix = var.name_prefix
   region      = var.region
 
@@ -440,6 +442,7 @@ module "grafana" {
 # Deploy Materialize instance with configured backend connections
 module "materialize_instance" {
   source                  = "../../../kubernetes/modules/materialize-instance"
+  environmentd_version    = var.materialize_version
   instance_name           = local.materialize_instance_name
   instance_namespace      = local.materialize_instance_namespace
   metadata_backend_url    = local.metadata_backend_url

--- a/gcp/examples/enterprise/variables.tf
+++ b/gcp/examples/enterprise/variables.tf
@@ -204,3 +204,9 @@ variable "datapath_provider" {
     error_message = "Datapath provider must be one of ADVANCED_DATAPATH, LEGACY_DATAPATH, or DATAPATH_PROVIDER_UNSPECIFIED"
   }
 }
+
+variable "materialize_version" {
+  description = "Materialize release for both the operator Helm chart and environmentd, which must not drift. Null uses each module's default."
+  type        = string
+  default     = null
+}

--- a/gcp/examples/simple/main.tf
+++ b/gcp/examples/simple/main.tf
@@ -333,6 +333,8 @@ module "self_signed_cluster_issuer" {
 module "operator" {
   source = "../../modules/operator"
 
+  operator_version = var.materialize_version
+
   name_prefix = var.name_prefix
   region      = var.region
 
@@ -401,6 +403,7 @@ module "grafana" {
 # Deploy Materialize instance with configured backend connections
 module "materialize_instance" {
   source                  = "../../../kubernetes/modules/materialize-instance"
+  environmentd_version    = var.materialize_version
   instance_name           = local.materialize_instance_name
   instance_namespace      = local.materialize_instance_namespace
   metadata_backend_url    = local.metadata_backend_url

--- a/gcp/examples/simple/variables.tf
+++ b/gcp/examples/simple/variables.tf
@@ -96,3 +96,9 @@ variable "datapath_provider" {
     error_message = "Datapath provider must be one of ADVANCED_DATAPATH, LEGACY_DATAPATH, or DATAPATH_PROVIDER_UNSPECIFIED"
   }
 }
+
+variable "materialize_version" {
+  description = "Materialize release for both the operator Helm chart and environmentd, which must not drift. Null uses each module's default."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Problem

The operator Helm chart version and the environmentd version are two independent variables in two different modules:

| Module | Variable | Marker |
|---|---|---|
| `{gcp,aws,azure}/modules/operator` | `operator_version` | `# META: helm-chart version` |
| `kubernetes/modules/materialize-instance` | `environmentd_version` | `# META: mz version` |

Their defaults are bumped together on every release, so an example that sets **neither** is always consistent. But none of the `enterprise` / `simple` examples expose a way to pin the Materialize version, so a consumer who wants to pin has to know to reach into two separate modules. Setting only one — the obvious thing to do — silently desynchronizes them, and nothing warns you.

I hit exactly this in a downstream deployment: environmentd on `v26.34.0` against an operator chart still on `v26.33.0`, unnoticed, because only `environmentd_version` had been overridden.

## Why it is more than untidy

The Materialize **CRD ships with the operator chart**, while `spec.enableRbac` and `spec.environmentId` are written by the **materialize-instance** module. The CRD is a structural schema with no `x-kubernetes-preserve-unknown-fields` on either `v1alpha1` or `v1`, so the API server **prunes unknown spec fields**.

If `materialize-instance` runs ahead of the operator, those fields are dropped silently. `enable_rbac` defaults to `true` in the module, so the result is **RBAC not enforced**, with `terraform apply` reporting success and the CR looking correct. A security control disabled with no error surfaced anywhere.

## Change

Add one `materialize_version` variable to each `enterprise` and `simple` example and feed it to both module inputs.

**Default `null`, so behaviour is unchanged unless set.** Both target variables are `nullable = false` with a default, and Terraform falls back to the default when `null` is assigned — verified with a scratch module rather than assumed:

```hcl
variable "v" { type = string, default = "MODULE_DEFAULT", nullable = false }
# passing null from the caller yields "MODULE_DEFAULT"
```

## Scope

- Modified: `{gcp,aws,azure}/examples/{enterprise,simple}` — 12 files, 60 insertions.
- **`migration` examples intentionally untouched** — they expose `operator_version` and `environmentd_version` separately, and a staged migration may genuinely need to move them independently.

## Testing

`terraform validate` passes for all six modified examples. No lock files or generated docs touched.

## Open question for reviewers

Should the `migration` examples get a note in their variable descriptions warning about the pruning behaviour above? I left them alone to keep this focused, but that is where independent versions are most likely to be set, and therefore where a silent prune is most likely to bite.