### PR TITLE
fix: ignore GKE controller-written LB annotations (perpetual plan diff)

### DIFF
--- a/gcp/modules/load_balancers/main.tf
+++ b/gcp/modules/load_balancers/main.tf
@@ -30,7 +30,8 @@ resource "kubernetes_service" "console_load_balancer" {
       # on any changes to the Materialize CR.
       metadata[0].name,
       spec[0].selector["materialize.cloud/name"],
-      metadata[0].annotations["cloud.google.com/neg"]
+      metadata[0].annotations["cloud.google.com/neg"],
+      metadata[0].annotations["networking.gke.io/target-pool"]
     ]
   }
   wait_for_load_balancer = true
@@ -73,7 +74,8 @@ resource "kubernetes_service" "balancerd_load_balancer" {
       # on any changes to the Materialize CR.
       metadata[0].name,
       spec[0].selector["materialize.cloud/name"],
-      metadata[0].annotations["cloud.google.com/neg"]
+      metadata[0].annotations["cloud.google.com/neg"],
+      metadata[0].annotations["networking.gke.io/target-pool"]
     ]
   }
   wait_for_load_balancer = true

--- a/kubernetes/modules/ory-stack/main.tf
+++ b/kubernetes/modules/ory-stack/main.tf
@@ -430,6 +430,13 @@ resource "kubernetes_service_v1" "ory_lb" {
 
   wait_for_load_balancer = true
 
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations["networking.gke.io/target-pool"],
+      metadata[0].annotations["cloud.google.com/neg"],
+    ]
+  }
+
   depends_on = [
     module.ory_kratos,
     module.ory_hydra,


### PR DESCRIPTION
## Problem

GKE's service controller stamps `networking.gke.io/target-pool` onto every L4 external `LoadBalancer` Service after creation. It is never present in Terraform config, so Terraform proposes removing it on **every** plan. Applying strips it, and GKE immediately re-adds it — a permanent phantom diff that can never be resolved by applying.

On a fresh `gcp/examples/enterprise` deployment this is **5 services** showing `will be updated in-place` on an otherwise clean plan:

```
  # module.load_balancers.kubernetes_service.balancerd_load_balancer will be updated in-place
  # module.load_balancers.kubernetes_service.console_load_balancer will be updated in-place
  # module.ory.kubernetes_service_v1.ory_lb["hydra-public-lb"] will be updated in-place
  # module.ory.kubernetes_service_v1.ory_lb["kratos-public-lb"] will be updated in-place
  # module.ory.kubernetes_service_v1.ory_lb["ory-selfservice-ui-lb"] will be updated in-place
```

with each diff being only:

```
  ~ annotations = {
      - "networking.gke.io/target-pool" = "a707dc6268bb74871a95daeedd3435c7" -> null
    }
```

## Fix

`gcp/modules/load_balancers` **already** ignores `cloud.google.com/neg` for exactly this reason, so the pattern and its rationale are established upstream — `target-pool` was simply missed. This adds it to the existing `ignore_changes` lists, and adds the equivalent `lifecycle` block to `ory-stack`'s LB service, which had none.

Both keys are GKE-specific. `kubernetes/modules/ory-stack` is cloud-agnostic, but ignoring an annotation that is never set is a no-op on AWS and Azure.

## Verification

Not just `terraform validate` — planned against a **live GKE enterprise deployment** with the modules repinned to this branch:

| | Plan |
|---|---|
| before | `0 to add, 7 to change, 0 to destroy` |
| after | `0 to add, 2 to change, 0 to destroy` |

All 5 LB services drop out. The 2 remaining are an artifact of the placeholder license key used for the test run (two Secrets embedding the JWT), not related to this change.