### PR TITLE
CLO-165: Document multi-AZ support in AWS modules

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -59,6 +59,20 @@ Depending on your needs, you can use the modules individually or combine them to
 
 ---
 
+## Multi-AZ Support
+
+These modules are designed for high availability across multiple AWS Availability Zones:
+
+- **Networking**: Creates one private and one public subnet per AZ via `availability_zones` list
+- **EKS**: Control plane is automatically HA across AZs; node groups span all private subnets
+- **Karpenter**: EC2NodeClass references all subnets, enabling node provisioning in any AZ
+- **EBS CSI**: StorageClass uses `WaitForFirstConsumer` to co-locate volumes with pods
+- **NLB**: Cross-zone load balancing enabled by default for even traffic distribution
+
+For detailed multi-AZ architecture documentation and cross-AZ data transfer cost considerations, see [`examples/simple/README.md`](./examples/simple/README.md#multi-az-architecture).
+
+---
+
 ## Getting Started
 
 ### Example Deployment

--- a/aws/examples/simple/README.md
+++ b/aws/examples/simple/README.md
@@ -260,6 +260,67 @@ instance_types_materialize = ["r7gd.8xlarge"]
 
 ---
 
+## Multi-AZ Architecture
+
+This deployment is designed for high availability across multiple AWS Availability Zones (AZs).
+
+### How Multi-AZ Works
+
+| Component | Multi-AZ Behavior |
+|-----------|-------------------|
+| **VPC/Subnets** | One private and one public subnet per AZ (3 AZs by default). Subnets map 1:1 with the `availability_zones` list. |
+| **EKS Control Plane** | Automatically distributed across multiple AZs by AWS for high availability. |
+| **EKS Node Groups** | Base node group spans all private subnets, placing nodes across all AZs. |
+| **Karpenter** | EC2NodeClass includes all private subnets, allowing Karpenter to provision nodes in any AZ based on workload demands. |
+| **EBS Volumes** | StorageClass uses `WaitForFirstConsumer` binding mode, ensuring volumes are created in the same AZ as the scheduled pod (EBS volumes are AZ-scoped). |
+| **Network Load Balancer** | Deployed across all subnets with cross-zone load balancing enabled by default. |
+| **RDS Database** | Defaults to single-AZ in this example. Set `multi_az = true` for production to enable synchronous standby replication. |
+| **NAT Gateway** | Single NAT Gateway by default (cost-saving). Set `single_nat_gateway = false` for HA (one NAT per AZ). |
+
+### Production Recommendations
+
+For production deployments, consider these changes:
+
+```hcl
+# In module "networking"
+single_nat_gateway = false  # One NAT Gateway per AZ for HA
+
+# In module "database"
+multi_az = true  # Synchronous standby in different AZ
+```
+
+---
+
+## Cross-AZ Data Transfer Costs
+
+AWS charges for data transfer between Availability Zones. Understanding these costs is important for production deployments.
+
+### Cost Overview
+
+| Traffic Type | Cost (approx.) | Notes |
+|--------------|----------------|-------|
+| Cross-AZ data transfer | ~$0.01/GB | Applies to traffic between AZs within the same region |
+| Same-AZ data transfer | Free | Traffic within the same AZ |
+| NAT Gateway processing | ~$0.045/GB | Plus ~$0.045/hour per gateway |
+
+### Where Cross-AZ Costs Apply
+
+1. **NLB Cross-Zone Load Balancing**: Enabled by default (`enable_cross_zone_load_balancing = true`). Traffic routed to targets in different AZs incurs cross-AZ charges. Disable with `enable_cross_zone_load_balancing = false` if cost is a concern and clients can be AZ-aware.
+
+2. **Pod-to-Pod Communication**: Pods on nodes in different AZs incur cross-AZ charges. Kubernetes does not provide AZ-aware service routing by default.
+
+3. **EKS Control Plane**: Communication between nodes and the EKS API server may cross AZs (AWS-managed, not directly configurable).
+
+4. **NAT Gateway**: With a single NAT Gateway (default), traffic from private subnets in other AZs crosses AZ boundaries. Multi-NAT (`single_nat_gateway = false`) keeps traffic within each AZ but increases fixed costs.
+
+### Cost Optimization Tips
+
+- **For dev/test**: Single NAT Gateway and single-AZ RDS reduce costs significantly.
+- **For production**: The HA benefits of multi-AZ typically outweigh the cross-AZ transfer costs. Budget ~$0.01/GB for cross-AZ traffic.
+- **Monitor costs**: Use AWS Cost Explorer to track "EC2-Other" charges, which include cross-AZ data transfer.
+
+---
+
 ## Notes
 
 * You can customize each module independently.

--- a/aws/examples/simple/main.tf
+++ b/aws/examples/simple/main.tf
@@ -51,6 +51,14 @@ provider "kubectl" {
 }
 
 # 1. Create network infrastructure
+#
+# Multi-AZ Topology:
+# - Creates one private and one public subnet in each availability zone
+# - Subnets map 1:1 with the availability_zones list (index 0 -> AZ a, etc.)
+# - Private subnets host EKS nodes; public subnets host NAT Gateway and
+#   internet-facing load balancers
+# - By default, a single NAT Gateway is used (cost-saving); set
+#   single_nat_gateway = false for HA (one NAT per AZ, higher cost)
 module "networking" {
   source      = "../../modules/networking"
   name_prefix = var.name_prefix
@@ -66,6 +74,9 @@ module "networking" {
 }
 
 # 2. Create EKS cluster
+#
+# Multi-AZ: The EKS control plane is automatically distributed across
+# multiple AZs by AWS for high availability.
 module "eks" {
   source                                   = "../../modules/eks"
   name_prefix                              = var.name_prefix
@@ -157,6 +168,10 @@ module "node_local_dns" {
 }
 
 # 2.2 Install Karpenter to manage creation of additional nodes
+#
+# Multi-AZ: Karpenter provisions nodes across all AZs automatically.
+# The EC2NodeClass resources (defined below) include all private subnet
+# IDs in their subnetSelectorTerms, enabling Karpenter to spread nodes.
 module "karpenter" {
   source = "../../modules/karpenter"
 
@@ -287,6 +302,11 @@ module "aws_lbc" {
 }
 
 # 4. Install EBS CSI Driver for dynamic EBS volume provisioning
+#
+# Multi-AZ: The gp3 StorageClass uses WaitForFirstConsumer binding mode,
+# which delays volume provisioning until a pod is scheduled. This ensures
+# EBS volumes are created in the same AZ as the node running the pod,
+# avoiding cross-AZ attachment failures (EBS volumes are AZ-scoped).
 module "ebs_csi_driver" {
   source = "../../modules/ebs-csi-driver"
 
@@ -383,6 +403,10 @@ resource "random_password" "external_login_password_mz_system" {
 }
 
 # 7. Setup dedicated database instance for Materialize
+#
+# Multi-AZ: The database defaults to single-AZ (multi_az = false) for this
+# demo/non-production example. For production, set multi_az = true to enable
+# synchronous standby replication in a different AZ for automatic failover.
 module "database" {
   source                    = "../../modules/database"
   name_prefix               = var.name_prefix
@@ -393,7 +417,7 @@ module "database" {
   database_name             = "materialize"
   database_username         = "materialize"
   database_password         = random_password.database_password.result
-  multi_az                  = false
+  multi_az                  = false # Set to true for production HA
   database_subnet_ids       = module.networking.private_subnet_ids
   vpc_id                    = module.networking.vpc_id
   cluster_name              = module.eks.cluster_name
@@ -513,6 +537,12 @@ module "grafana" {
 }
 
 # 11. Setup dedicated NLB for Materialize instance
+#
+# Multi-AZ: The NLB is deployed across all subnets (public for internet-
+# facing, private for internal). Cross-zone load balancing is enabled by
+# default (enable_cross_zone_load_balancing = true), ensuring traffic is
+# distributed evenly across targets in all AZs regardless of client AZ.
+# Note: Cross-zone LB incurs ~$0.01/GB for cross-AZ data transfer.
 module "materialize_nlb" {
   source = "../../modules/nlb"
 


### PR DESCRIPTION
## Summary

- Add inline comments to `examples/simple/main.tf` explaining multi-AZ topology for key modules
- Add "Multi-AZ Architecture" section to `examples/simple/README.md` with component breakdown
- Add "Cross-AZ Data Transfer Costs" section with cost tables and optimization tips
- Add brief multi-AZ overview to `aws/README.md` linking to detailed docs

## Context

https://linear.app/materializeinc/issue/CLO-165/audit-and-document-current-multi-az-support-in-aws-modules

This PR audits and documents the existing multi-AZ support in AWS terraform modules. The audit confirmed:

| Component | Multi-AZ Status |
|-----------|-----------------|
| Networking | ✅ Per-AZ subnets via `terraform-aws-modules/vpc/aws` |
| EKS/Karpenter | ✅ Nodes span all private subnets via EC2NodeClass `subnetSelectorTerms` |
| EBS CSI | ✅ `WaitForFirstConsumer` binding mode ensures AZ-local volumes |
| NLB | ✅ Cross-zone load balancing enabled by default |
| RDS Database | ⚠️ Defaults to single-AZ (documented as non-production) |
| NAT Gateway | ⚠️ Single NAT by default (documented as cost-saving option) |

No gaps were found - the `# TODO zone?` comments in the codebase are design choices, not missing functionality. Database and NAT Gateway single-AZ defaults are intentional for cost optimization in non-production environments.

## Test plan

- [x] `terraform fmt -recursive` passes
- [x] `tflint --recursive` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)