### PR TITLE
feat(ory-kratos): keep upstream OIDC client secrets out of the ConfigMap

### DIFF
--- a/kubernetes/modules/ory-kratos/README.md
+++ b/kubernetes/modules/ory-kratos/README.md
@@ -35,6 +35,7 @@ No modules.
 | ---- | ---- |
 | [helm_release.kratos](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_namespace.kratos](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_secret.upstream_oidc_providers_env](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [random_password.secrets_cipher](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.secrets_cookie](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.secrets_default](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |

--- a/kubernetes/modules/ory-kratos/main.tf
+++ b/kubernetes/modules/ory-kratos/main.tf
@@ -24,6 +24,24 @@ resource "random_password" "secrets_cipher" {
   special = false
 }
 
+# The entire provider list — including client secrets — lives in this Secret
+# and reaches Kratos as a single JSON-valued environment variable, so the
+# Helm-rendered ConfigMap never carries a credential.
+resource "kubernetes_secret" "upstream_oidc_providers_env" {
+  count = length(var.upstream_oidc_providers) > 0 ? 1 : 0
+
+  metadata {
+    name      = "${var.release_name}-upstream-oidc-providers"
+    namespace = local.namespace
+  }
+
+  data = {
+    providers = jsonencode(local.upstream_oidc_provider_objects)
+  }
+
+  type = "Opaque"
+}
+
 locals {
   namespace = var.create_namespace ? kubernetes_namespace.kratos[0].metadata[0].name : var.namespace
 
@@ -66,25 +84,22 @@ locals {
     }
   } : {}
 
-  tls_deployment_config = local.tls_enabled ? {
-    deployment = {
-      extraVolumes = [
-        {
-          name = "tls-cert"
-          secret = {
-            secretName = var.tls_cert_secret_name
-          }
-        },
-      ]
-      extraVolumeMounts = [
-        {
-          name      = "tls-cert"
-          mountPath = local.tls_mount_dir
-          readOnly  = true
-        },
-      ]
-    }
-  } : {}
+  tls_volumes = local.tls_enabled ? [
+    {
+      name = "tls-cert"
+      secret = {
+        secretName = var.tls_cert_secret_name
+      }
+    },
+  ] : []
+
+  tls_volume_mounts = local.tls_enabled ? [
+    {
+      name      = "tls-cert"
+      mountPath = local.tls_mount_dir
+      readOnly  = true
+    },
+  ] : []
 
   smtp_config = var.smtp_connection_uri != null ? {
     courier = {
@@ -118,6 +133,62 @@ locals {
 
   upstream_oidc_mapper_data_uri = "base64://${base64encode(local.upstream_oidc_mapper_jsonnet)}"
 
+  # The provider objects as Kratos expects them. They only ever land in a
+  # Kubernetes Secret, never in the Helm-rendered ConfigMap.
+  upstream_oidc_provider_objects = [
+    for p in var.upstream_oidc_providers : merge(
+      {
+        id            = p.id
+        provider      = p.provider
+        client_id     = p.client_id
+        client_secret = p.client_secret
+        issuer_url    = p.issuer_url
+        scope         = p.scope
+        mapper_url    = local.upstream_oidc_mapper_data_uri
+      },
+      p.label != null ? { label = p.label } : {},
+    )
+  ]
+
+  # The provider list reaches Kratos as one JSON-valued environment variable;
+  # configx decodes JSON env values into arrays and the variable takes
+  # precedence over the (provider-less) file configuration. This is the
+  # delivery mechanism Ory recommends for keeping provider secrets out of the
+  # chart's ConfigMap: https://github.com/ory/k8s/issues/423
+  upstream_oidc_extra_env = length(var.upstream_oidc_providers) > 0 ? [
+    {
+      name = "SELFSERVICE_METHODS_OIDC_CONFIG_PROVIDERS"
+      valueFrom = {
+        secretKeyRef = {
+          name = kubernetes_secret.upstream_oidc_providers_env[0].metadata[0].name
+          key  = "providers"
+        }
+      }
+    },
+  ] : []
+
+  # Roll the pods when the provider list changes: the chart's checksum
+  # annotation only covers the ConfigMap, and environment variables are
+  # immutable for running pods. The annotation lands on the pod template, so a
+  # changed hash triggers a rolling restart.
+  upstream_oidc_env_annotations = length(var.upstream_oidc_providers) > 0 ? {
+    "checksum/upstream-oidc-providers" = sha256(jsonencode(local.upstream_oidc_provider_objects))
+  } : {}
+
+  deployment_config = length(local.tls_volumes) > 0 || length(local.upstream_oidc_extra_env) > 0 ? {
+    deployment = merge(
+      length(local.tls_volumes) > 0 ? {
+        extraVolumes      = local.tls_volumes
+        extraVolumeMounts = local.tls_volume_mounts
+      } : {},
+      length(local.upstream_oidc_extra_env) > 0 ? { extraEnv = local.upstream_oidc_extra_env } : {},
+      length(local.upstream_oidc_env_annotations) > 0 ? { annotations = local.upstream_oidc_env_annotations } : {},
+    )
+  } : {}
+
+  # The providers themselves are delivered exclusively via the environment
+  # variable; enabled-with-no-providers is valid configuration for workloads
+  # that never receive it (migration job, courier).
   upstream_oidc_config = length(var.upstream_oidc_providers) > 0 ? {
     kratos = {
       config = {
@@ -125,22 +196,6 @@ locals {
           methods = {
             oidc = {
               enabled = true
-              config = {
-                providers = [
-                  for p in var.upstream_oidc_providers : merge(
-                    {
-                      id            = p.id
-                      provider      = p.provider
-                      client_id     = p.client_id
-                      client_secret = p.client_secret
-                      issuer_url    = p.issuer_url
-                      scope         = p.scope
-                      mapper_url    = local.upstream_oidc_mapper_data_uri
-                    },
-                    p.label != null ? { label = p.label } : {},
-                  )
-                ]
-              }
             }
           }
         }
@@ -239,7 +294,7 @@ locals {
   default_helm_values_with_extras = provider::deepmerge::mergo(
     provider::deepmerge::mergo(
       provider::deepmerge::mergo(local.default_helm_values, local.tls_kratos_config),
-      local.tls_deployment_config,
+      local.deployment_config,
     ),
     local.upstream_oidc_config,
   )


### PR DESCRIPTION
## Problem

The Ory Kratos Helm chart renders all of `kratos.config` into a **ConfigMap** (`templates/configmap-config.yaml`). Because this module passed `upstream_oidc_providers[].client_secret` through as part of that config, every upstream IdP client secret ended up in a ConfigMap, where it

- is **not** covered by Kubernetes Secret encryption at rest,
- is readable by anyone holding `get configmap` — a far more commonly granted verb than `get secret`,
- appears unredacted in `kubectl describe`, support bundles, and cluster backups.

The chart itself already treats `dsn`, `secrets.*`, and the SMTP URI as too sensitive for the ConfigMap and routes them through a Secret; upstream provider credentials were the remaining exception.

## Solution

The provider list — including client secrets — now lives in a Kubernetes Secret owned by the module and reaches Kratos as a single JSON-valued environment variable, injected via `secretKeyRef`:

```
SELFSERVICE_METHODS_OIDC_CONFIG_PROVIDERS = <JSON array of provider objects>
```

Kratos's config loader (`ory/x/configx`) JSON-decodes environment values into arrays and gives the variable precedence over the file configuration, so this works with every released Kratos. It is also the pattern ory/k8s#423 (the upstream ask for exactly this capability) was closed with.

**No provider credential reaches the Helm-rendered ConfigMap under any configuration** — there is deliberately no inline option and no new knob to hold wrong. `upstream_oidc_providers` keeps its interface; the delivery mechanism is entirely internal to the module.

## Implementation notes

- The rendered config keeps `selfservice.methods.oidc.enabled: true` with **no** `providers` key (schema-valid), so workloads that never receive the env var — the migration job, courier — boot unchanged.
- A `checksum/upstream-oidc-providers` pod-template annotation forces a rolling restart when the provider list changes: environment variables are immutable for running pods, and the chart's own checksum annotation only covers the ConfigMap.
- `deployment.extraEnv` and the TLS `extraVolumes` are assembled in one deployment block because mergo replaces lists rather than appending them.

## Migration

Existing deployments with `upstream_oidc_providers` set will see: one new Secret, the env var on the Kratos deployment, providers dropping out of the ConfigMap, and a single rolling restart. No variable changes are required.

Note (not written by Claude): given this feature is not yet released to customers, I think breaking changes are fine right now.

## Testing

- `terraform validate` on `ory-kratos` and `ory-stack`.
- Module READMEs regenerated with `.github/scripts/generate-docs.sh`.
- The env-var mechanism (JSON array decode, precedence over file config) verified against the Kratos codebase (`oryx/configx/koanf_env.go`) and empirically with a config-load test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
