### PR TITLE
CLO-167: Update GCP networking and storage for multi-zone support

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -27,6 +27,7 @@ GCP Specific Modules:
 | [`modules/nodepool`](./modules/nodepool)        | Additional GKE node pools with autoscaling                     |
 | [`modules/database`](./modules/database)        | Cloud SQL PostgreSQL for Materialize metadata                 |
 | [`modules/storage`](./modules/storage)          | Cloud Storage bucket with HMAC keys for S3-compatible access   |
+| [`modules/storage-class`](./modules/storage-class) | Kubernetes StorageClass for GCP Persistent Disks (optional)  |
 | [`modules/load_balancers`](./modules/load_balancers) | GCP Load Balancers for Materialize instance access      |
 | [`modules/operator`](./modules/operator)        | Materialize Kubernetes operator installation                   |
 
@@ -100,3 +101,87 @@ provider "helm" {
 ### Required APIs
 
 Your GCP project needs several APIs enabled. See the [examples/simple/README.md](./examples/simple/README.md#required-apis) for the complete list of required APIs and how to enable them.
+
+---
+
+## Multi-Zone Deployments
+
+GKE supports multi-zone deployments for high availability. This section explains how networking, storage, and zones interact.
+
+### Zone Configuration
+
+By default, GKE regional clusters distribute nodes across all zones in the region. You can optionally restrict nodes to specific zones:
+
+```hcl
+module "gke" {
+  source = "../../modules/gke"
+  # ...
+  region         = "us-central1"
+  node_locations = ["us-central1-a", "us-central1-b"]  # Optional: limit to specific zones
+}
+```
+
+**When to specify zones:**
+- **Cost optimization**: Fewer zones = fewer nodes = lower cost
+- **Machine type availability**: Some machine types aren't available in all zones
+- **Data locality**: Keep workloads closer to specific data sources
+
+### Networking (Subnets)
+
+GCP subnets are **regional resources**, not zonal. A single subnet automatically spans all zones in its region. This means:
+- No subnet changes needed for multi-zone deployments
+- Nodes in any zone can use the same subnet and IP ranges
+- Pod and service CIDR ranges work across all zones
+
+### Storage (Persistent Disks)
+
+GCP Persistent Disks (PDs) are **zonal resources**. A PD can only be attached to a node in the same zone. This has important implications:
+
+#### The Problem with Default Volume Binding
+
+With the default `Immediate` volume binding mode, Kubernetes creates the PD as soon as the PVC is created—before knowing where the pod will be scheduled. If the pod gets scheduled to a different zone than the PD, it cannot start.
+
+#### The Solution: WaitForFirstConsumer
+
+GKE's default storage class `standard-rwo` uses `volumeBindingMode: WaitForFirstConsumer`, which:
+1. Delays PD creation until a pod using the PVC is scheduled
+2. Creates the PD in the same zone as the scheduled node
+3. Ensures pods can always access their volumes
+
+**This is why we recommend using `standard-rwo` (or our storage-class module) for multi-zone deployments.**
+
+#### Storage Class Options
+
+| Storage Class | Disk Type | Binding Mode | Use Case |
+|---------------|-----------|--------------|----------|
+| `standard` | pd-standard (HDD) | Immediate | Legacy, not recommended for multi-zone |
+| `standard-rwo` | pd-balanced | WaitForFirstConsumer | **Recommended default** |
+| `premium-rwo` | pd-ssd | WaitForFirstConsumer | Higher performance workloads |
+
+For custom storage classes, use the [`modules/storage-class`](./modules/storage-class) module.
+
+#### Regional Persistent Disks
+
+For zone-level fault tolerance, you can use Regional Persistent Disks which replicate data across two zones:
+
+```hcl
+module "storage_class" {
+  source = "../../modules/storage-class"
+
+  storage_class_name = "regional-pd-ssd"
+  disk_type          = "pd-ssd"
+  replication_type   = "regional-pd"
+}
+```
+
+**Trade-offs:**
+- Higher availability (survives single zone failure)
+- Higher cost (~2x zonal PD pricing)
+- Slightly higher latency for writes
+
+### StatefulSets and Multi-Zone
+
+StatefulSets work well with multi-zone deployments because:
+- Each replica gets its own PVC
+- `WaitForFirstConsumer` ensures each PD is created in the zone where its pod runs
+- Pod-to-PD zone affinity is maintained across restarts

--- a/gcp/examples/simple/main.tf
+++ b/gcp/examples/simple/main.tf
@@ -152,7 +152,10 @@ locals {
       }
     }]
   })
-  storage_class = "standard-rwo" # default storage class in gcp
+  # GKE's default 'standard-rwo' uses volumeBindingMode: WaitForFirstConsumer,
+  # which is essential for multi-zone clusters - it ensures PDs are created in
+  # the same zone as the scheduled pod. See gcp/modules/storage-class for custom options.
+  storage_class = "standard-rwo"
 }
 
 # Configure networking infrastructure including VPC, subnets, and CIDR blocks
@@ -167,6 +170,14 @@ module "networking" {
 }
 
 # Set up Google Kubernetes Engine (GKE) cluster
+#
+# Multi-zone configuration: By default, this creates a regional cluster with nodes
+# distributed across all zones in the region. Use var.zones to restrict nodes to
+# specific zones (e.g., for cost optimization or specific machine type availability).
+#
+# Note on Persistent Disks: GCP PDs are zonal resources. The default 'standard-rwo'
+# StorageClass uses WaitForFirstConsumer binding mode, ensuring volumes are created
+# in the same zone as the scheduled pod. This is critical for multi-zone deployments.
 module "gke" {
   source = "../../modules/gke"
 
@@ -182,6 +193,10 @@ module "gke" {
   namespace                         = local.materialize_operator_namespace
   k8s_apiserver_authorized_networks = var.k8s_apiserver_authorized_networks
   labels                            = var.labels
+
+  # Optional: Restrict nodes to specific zones. If null, uses all zones in the region.
+  # Example: ["us-central1-a", "us-central1-b"] for 2-zone HA deployment
+  node_locations = var.zones
 
   # Pinned to STABLE: REGULAR's 1.35.x line regressed cleanup of the per-cluster
   # k8s-<cluster-uid>-node-http-hc firewall on cluster destroy, leaving the VPC

--- a/gcp/examples/simple/variables.tf
+++ b/gcp/examples/simple/variables.tf
@@ -9,6 +9,36 @@ variable "region" {
   default     = "us-central1"
 }
 
+variable "zones" {
+  description = <<-EOT
+    List of zones within the region where GKE nodes can be created (e.g., ["us-central1-a", "us-central1-b"]).
+    If not specified (null), GKE will use all available zones in the region.
+
+    IMPORTANT: All zones must be within the specified region. For example, if region is "us-central1",
+    valid zones are "us-central1-a", "us-central1-b", "us-central1-c", "us-central1-f".
+    Using zones from a different region will cause deployment failures.
+
+    Multi-zone considerations:
+    - GCP Persistent Disks are zonal resources, meaning a PD can only be attached to a node in the same zone.
+    - The default storage class 'standard-rwo' uses 'WaitForFirstConsumer' binding mode, which ensures
+      PDs are created in the same zone as the scheduled pod.
+    - For high availability, use at least 2 zones. For cost optimization, you can limit to fewer zones.
+
+    Example:
+      zones = ["us-central1-a", "us-central1-b", "us-central1-c"]  # Multi-zone HA
+      zones = ["us-central1-a"]  # Single-zone (lower cost, no zone redundancy)
+      zones = null  # Use all zones in the region (default)
+  EOT
+  type        = list(string)
+  default     = null
+  nullable    = true
+
+  validation {
+    condition     = var.zones == null || length(var.zones) > 0
+    error_message = "If specified, zones must contain at least one zone."
+  }
+}
+
 variable "labels" {
   description = "Labels to apply to resources created."
   type        = map(string)

--- a/gcp/modules/gke/main.tf
+++ b/gcp/modules/gke/main.tf
@@ -27,6 +27,16 @@ locals {
   conversion_webhook_rule_source_ranges = (local.master_ipv4_cidr_block != "" && local.master_ipv4_cidr_block != null) ? local.master_ipv4_cidr_block : "0.0.0.0/0"
 }
 
+# GKE Cluster
+#
+# Multi-zone support: Setting location to a region (e.g., "us-central1") creates
+# a regional cluster with the control plane replicated across zones for high
+# availability. By default, nodes can be created in any zone within the region.
+# Use the node_locations variable to restrict nodes to specific zones.
+#
+# Note on Persistent Disks: GCP PDs are zonal. When using PVCs with zonal PDs,
+# ensure your StorageClass uses volumeBindingMode: WaitForFirstConsumer so the
+# PD is created in the same zone as the scheduled pod.
 resource "google_container_cluster" "primary" {
   provider = google
 
@@ -37,9 +47,10 @@ resource "google_container_cluster" "primary" {
     google_service_account.workload_identity_sa,
   ]
 
-  name     = "${var.prefix}-gke"
-  location = var.region
-  project  = var.project_id
+  name           = "${var.prefix}-gke"
+  location       = var.region
+  node_locations = var.node_locations
+  project        = var.project_id
 
   networking_mode = var.networking_mode
   network         = var.network_name

--- a/gcp/modules/gke/outputs.tf
+++ b/gcp/modules/gke/outputs.tf
@@ -33,3 +33,8 @@ output "workload_identity_sa_email" {
   description = "The email of the Workload Identity service account"
   value       = google_service_account.workload_identity_sa.email
 }
+
+output "node_locations" {
+  description = "The zones where cluster nodes can be created"
+  value       = google_container_cluster.primary.node_locations
+}

--- a/gcp/modules/gke/variables.tf
+++ b/gcp/modules/gke/variables.tf
@@ -118,3 +118,20 @@ variable "k8s_apiserver_authorized_networks" {
   }]
   nullable = false
 }
+
+variable "node_locations" {
+  description = <<-EOT
+    List of zones where nodes can be created (e.g., ["us-central1-a", "us-central1-b"]).
+    If not specified, GKE will automatically use all zones in the region for a regional cluster.
+
+    Use this to:
+    - Limit node placement to specific zones for cost optimization
+    - Ensure nodes run in zones with specific machine types available
+    - Control the distribution of workloads across zones
+
+    Note: All specified zones must be within the cluster's region.
+  EOT
+  type        = list(string)
+  default     = null
+  nullable    = true
+}

--- a/gcp/modules/networking/main.tf
+++ b/gcp/modules/networking/main.tf
@@ -17,6 +17,14 @@ locals {
   }
 }
 
+# VPC and Subnets
+#
+# Note on multi-zone support: GCP subnets are regional resources (not zonal),
+# meaning a single subnet automatically spans all zones within its region. This
+# design works seamlessly with regional GKE clusters - nodes in any zone can use
+# the same subnet and IP ranges. No subnet changes are needed for multi-zone
+# deployments; the same subnet configuration supports both single-zone and
+# multi-zone GKE clusters.
 module "vpc" {
   source  = "terraform-google-modules/network/google"
   version = "11.1.1"

--- a/gcp/modules/storage-class/README.md
+++ b/gcp/modules/storage-class/README.md
@@ -1,0 +1,109 @@
+# GCP Storage Class Module
+
+This module creates a Kubernetes StorageClass optimized for GCP Persistent Disks in multi-zone GKE clusters.
+
+## Why This Module?
+
+GCP Persistent Disks are **zonal resources** - they exist in a single zone and can only be attached to nodes in that same zone. In multi-zone GKE clusters, this creates a challenge: if you create a PersistentVolume before knowing where the pod will run, the pod might get scheduled to a different zone than where its storage lives, causing the pod to fail.
+
+This module creates a StorageClass with `volumeBindingMode: WaitForFirstConsumer`, which solves this problem by delaying volume creation until a pod is scheduled. The CSI driver then creates the Persistent Disk in the same zone as the scheduled node.
+
+## GKE Default Storage Classes
+
+GKE automatically creates several storage classes:
+
+| Name | Disk Type | Binding Mode | Notes |
+|------|-----------|--------------|-------|
+| `standard` | pd-standard (HDD) | Immediate | Legacy, not recommended for multi-zone |
+| `standard-rwo` | pd-balanced | WaitForFirstConsumer | **Recommended default** |
+| `premium-rwo` | pd-ssd | WaitForFirstConsumer | Higher performance |
+
+The `standard-rwo` class already uses `WaitForFirstConsumer` and works well for most use cases. Use this module when you need:
+- A custom storage class name
+- Specific disk type configuration
+- Volume expansion settings
+- Regional Persistent Disk replication
+
+## Usage
+
+### Using GKE Default (Recommended for Most Users)
+
+If you're happy with `standard-rwo`, you don't need this module:
+
+```hcl
+locals {
+  storage_class = "standard-rwo"  # GKE default, already has WaitForFirstConsumer
+}
+```
+
+### Creating a Custom SSD Storage Class
+
+```hcl
+module "storage_class" {
+  source = "../../modules/storage-class"
+
+  storage_class_name = "pd-ssd"
+  disk_type          = "pd-ssd"
+  set_as_default     = false
+}
+```
+
+### Creating a Regional Persistent Disk Storage Class
+
+For higher availability, you can use regional PDs that replicate across two zones:
+
+```hcl
+module "storage_class" {
+  source = "../../modules/storage-class"
+
+  storage_class_name = "regional-pd-ssd"
+  disk_type          = "pd-ssd"
+  replication_type   = "regional-pd"
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.0 |
+| kubernetes | >= 2.10.0, < 2.39.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| create_storage_class | Whether to create the storage class | `bool` | `true` | no |
+| storage_class_name | Name of the Kubernetes StorageClass | `string` | `"pd-ssd"` | no |
+| disk_type | Type of GCP Persistent Disk (pd-standard, pd-ssd, pd-balanced, pd-extreme) | `string` | `"pd-ssd"` | no |
+| reclaim_policy | Reclaim policy (Delete, Retain) | `string` | `"Delete"` | no |
+| allow_volume_expansion | Allow volume expansion after creation | `bool` | `true` | no |
+| set_as_default | Set as cluster default storage class | `bool` | `false` | no |
+| replication_type | Disk replication (none, regional-pd) | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| storage_class_name | Name of the storage class |
+
+## Multi-Zone Considerations
+
+### Zonal vs Regional Persistent Disks
+
+- **Zonal PDs** (default): Lower cost, data in one zone. If that zone fails, data is inaccessible until the zone recovers.
+- **Regional PDs** (`replication_type = "regional-pd"`): Higher cost, data replicated across two zones. Provides zone-level fault tolerance.
+
+### Pod Scheduling with Zonal PDs
+
+With `WaitForFirstConsumer`:
+1. Pod is created and needs a PVC
+2. Kubernetes schedules the pod to a node (e.g., in `us-central1-a`)
+3. The CSI driver creates the PD in `us-central1-a`
+4. Pod starts successfully
+
+If the pod is rescheduled (e.g., node failure), it will only be scheduled to nodes in `us-central1-a` where its volume exists.
+
+### StatefulSets
+
+StatefulSets work well with this pattern because each replica gets its own PVC, and the `WaitForFirstConsumer` binding ensures each volume is created in the zone where its pod runs.

--- a/gcp/modules/storage-class/main.tf
+++ b/gcp/modules/storage-class/main.tf
@@ -1,0 +1,42 @@
+# GCP Persistent Disk Storage Class for Kubernetes
+#
+# This module creates a Kubernetes StorageClass optimized for GCP zonal
+# Persistent Disks in multi-zone GKE clusters.
+#
+# Why WaitForFirstConsumer?
+# -------------------------
+# GCP Persistent Disks (PDs) are zonal resources - they exist in a single zone
+# and can only be attached to nodes in that same zone. In a multi-zone GKE
+# cluster, using the default "Immediate" volume binding mode would create the PD
+# in an arbitrary zone before knowing where the pod will be scheduled. This can
+# cause scheduling failures if the pod gets scheduled to a different zone.
+#
+# Using "WaitForFirstConsumer" delays PD creation until a pod using the PVC is
+# scheduled. The CSI driver then creates the PD in the same zone as the node,
+# ensuring the volume is always accessible to the pod.
+#
+# This is especially important for StatefulSets and pods with persistent storage
+# in multi-zone deployments.
+
+resource "kubernetes_storage_class" "pd_ssd" {
+  count = var.create_storage_class ? 1 : 0
+
+  metadata {
+    name = var.storage_class_name
+    annotations = var.set_as_default ? {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    } : {}
+  }
+
+  storage_provisioner    = "pd.csi.storage.gke.io"
+  reclaim_policy         = var.reclaim_policy
+  volume_binding_mode    = "WaitForFirstConsumer"
+  allow_volume_expansion = var.allow_volume_expansion
+
+  parameters = merge(
+    {
+      type = var.disk_type
+    },
+    var.replication_type != null ? { "replication-type" = var.replication_type } : {}
+  )
+}

--- a/gcp/modules/storage-class/outputs.tf
+++ b/gcp/modules/storage-class/outputs.tf
@@ -1,0 +1,4 @@
+output "storage_class_name" {
+  description = "Name of the created storage class, or the configured name if creation was skipped"
+  value       = var.create_storage_class ? kubernetes_storage_class.pd_ssd[0].metadata[0].name : var.storage_class_name
+}

--- a/gcp/modules/storage-class/variables.tf
+++ b/gcp/modules/storage-class/variables.tf
@@ -1,0 +1,72 @@
+variable "create_storage_class" {
+  description = "Whether to create the storage class. Set to false if using GKE's default 'standard-rwo' class which already has WaitForFirstConsumer."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "storage_class_name" {
+  description = "Name of the Kubernetes StorageClass to create"
+  type        = string
+  default     = "pd-ssd"
+  nullable    = false
+}
+
+variable "disk_type" {
+  description = <<-EOT
+    Type of GCP Persistent Disk:
+    - pd-standard: HDD, lowest cost, suitable for batch workloads
+    - pd-balanced: Balanced SSD, good price/performance ratio (default for standard-rwo)
+    - pd-ssd: SSD, higher performance than pd-balanced
+    - pd-extreme: Highest performance SSD, requires provisioned IOPS and minimum 500GB size
+
+    Note: pd-extreme disks have additional requirements and higher costs.
+    See https://cloud.google.com/compute/docs/disks/extreme-persistent-disk
+  EOT
+  type        = string
+  default     = "pd-ssd"
+  nullable    = false
+
+  validation {
+    condition     = contains(["pd-standard", "pd-ssd", "pd-balanced", "pd-extreme"], var.disk_type)
+    error_message = "disk_type must be one of: pd-standard, pd-ssd, pd-balanced, pd-extreme"
+  }
+}
+
+variable "reclaim_policy" {
+  description = "Reclaim policy for persistent volumes. Options: Delete, Retain"
+  type        = string
+  default     = "Delete"
+  nullable    = false
+
+  validation {
+    condition     = contains(["Delete", "Retain"], var.reclaim_policy)
+    error_message = "reclaim_policy must be either 'Delete' or 'Retain'"
+  }
+}
+
+variable "allow_volume_expansion" {
+  description = "Whether to allow volume expansion after creation"
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "set_as_default" {
+  description = "Whether to set this storage class as the cluster default"
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "replication_type" {
+  description = "Replication type for the disk. Options: none (zonal), regional-pd (regional). Regional PDs replicate data across two zones for higher availability but cost more."
+  type        = string
+  default     = null
+  nullable    = true
+
+  validation {
+    condition     = var.replication_type == null || contains(["none", "regional-pd"], var.replication_type)
+    error_message = "replication_type must be null, 'none', or 'regional-pd'"
+  }
+}

--- a/gcp/modules/storage-class/versions.tf
+++ b/gcp/modules/storage-class/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10.0, < 2.39.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `node_locations` variable to GKE module for explicit zone control in multi-zone deployments
- Create new `storage-class` module with `volumeBindingMode: WaitForFirstConsumer` for proper zonal PD provisioning
- Add `zones` variable to the simple example demonstrating multi-zone configuration
- Update networking module with documentation confirming regional subnets work seamlessly with multi-zone GKE clusters
- Add comprehensive documentation about zone selection and PD topology constraints

## Context

GCP Persistent Disks are zonal resources, so pods must schedule where their volumes live. This PR ensures storage configuration handles this properly by:

1. Documenting that GKE's default `standard-rwo` StorageClass already uses `WaitForFirstConsumer`
2. Providing an optional `storage-class` module for users who need custom configurations
3. Adding `node_locations` support to control which zones nodes can be created in

## Test plan

- [ ] CI passes (Terraform fmt/validate)
- [ ] Verify new storage-class module validates correctly
- [ ] Review documentation for accuracy

## Related

https://linear.app/materializeinc/issue/CLO-167/update-gcp-networking-and-storage-for-multi-zone-support

---

🤖 Generated with [Claude Code](https://claude.ai/code)