### PR TITLE
test: assert the default DNS deployments were scaled down

### DIFF
--- a/test/src/commands/verify.rs
+++ b/test/src/commands/verify.rs
@@ -42,6 +42,9 @@ pub async fn phase_verify(dir: &Path) -> Result<()> {
         println!("\nVerifying node-local-dns...");
         verify_node_local_dns(&kubeconfig, provider).await?;
 
+        println!("\nVerifying the default DNS deployments were scaled down...");
+        verify_default_dns_scaled_down(&kubeconfig, provider).await?;
+
         if let Some(endpoint) = outputs.load_balancer_endpoint() {
             println!("\nVerifying Materialize SQL connectivity at {endpoint}...");
             verify_sql_connection(endpoint, &outputs).await?;
@@ -312,6 +315,63 @@ async fn verify_node_local_dns(kubeconfig: &Path, provider: CloudProvider) -> Re
     .context("node-local-dns DaemonSet did not become ready within timeout")?;
 
     println!("  node-local-dns DaemonSet is ready.");
+    Ok(())
+}
+
+/// The kube-system deployments that kubernetes/modules/coredns scales to zero,
+/// so that only its custom CoreDNS serves DNS. Names differ per provider and
+/// match what {provider}/examples/simple passes to the module.
+///
+/// AWS lists no autoscaler on purpose: EKS ships no CoreDNS autoscaler
+/// deployment, so aws/examples/simple sets
+/// `disable_default_coredns_autoscaler = false` and nothing scales it.
+fn scaled_down_dns_deployments(provider: CloudProvider) -> &'static [&'static str] {
+    match provider {
+        CloudProvider::Aws => &["coredns"],
+        CloudProvider::Gcp => &["kube-dns", "kube-dns-autoscaler"],
+        CloudProvider::Azure => &["coredns", "coredns-autoscaler"],
+    }
+}
+
+/// Checks that the provider's default DNS deployments really are at zero
+/// replicas.
+///
+/// The scale-down runs in a local-exec provisioner, and it treats a missing
+/// deployment as success, so a wrong deployment name leaves the default DNS
+/// running and still reports a clean apply. Nothing else here would notice:
+/// Materialize comes up fine with two DNS stacks. Reading the replica count
+/// back is what turns that silent no-op into a failure.
+///
+/// A deployment that does not exist at all is accepted, matching the
+/// provisioner's own contract — the provider may never have created it.
+async fn verify_default_dns_scaled_down(kubeconfig: &Path, provider: CloudProvider) -> Result<()> {
+    for deployment in scaled_down_dns_deployments(provider) {
+        // --ignore-not-found keeps an absent deployment on the success path,
+        // so it is distinguishable from a genuine kubectl failure.
+        let replicas = run_cmd_output(kubectl(kubeconfig).args([
+            "get",
+            "deployment",
+            deployment,
+            "-n",
+            "kube-system",
+            "--ignore-not-found",
+            "-o",
+            "jsonpath={.spec.replicas}",
+        ]))
+        .await
+        .with_context(|| format!("Failed to read replica count for {deployment}"))?;
+
+        match replicas.as_str() {
+            "" => println!("  {deployment} does not exist, nothing to scale down."),
+            "0" => println!("  [ok] {deployment} is scaled to 0 replicas."),
+            other => bail!(
+                "expected deployment {deployment} in kube-system to be scaled to 0 \
+                 replicas, found {other}. The default DNS stack is still running \
+                 alongside the custom CoreDNS."
+            ),
+        }
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Closes the coverage gap found while reviewing #301 and #346: nothing verified that the coredns module's scale-down actually took effect.

## Why

`kubernetes/modules/coredns` scales the provider's default kube-dns deployment (and its autoscaler) to zero so only its custom CoreDNS serves DNS. The verify phase checks the Materialize instance is `UpToDate`, the expected pods run, `node-local-dns` is ready, and `SELECT 1` works — every one of which holds just as well with **two DNS stacks running side by side**.

That gap has teeth because the scale-down provisioner treats a missing deployment as success (`no objects passed to scale` → exit 0). A wrong deployment name leaves the default DNS untouched *and* reports a clean apply. Reading the replica count back is what turns that silent no-op into a failure.

## What it checks

Per provider, matching what each `{provider}/examples/simple` passes to the module:

| Provider | Deployments asserted at 0 replicas |
|---|---|
| AWS | `coredns` |
| GCP | `kube-dns`, `kube-dns-autoscaler` |
| Azure | `coredns`, `coredns-autoscaler` |

AWS lists no autoscaler because EKS ships none, so its example sets `disable_default_coredns_autoscaler = false` and nothing scales it.

A deployment that does not exist at all is still accepted, matching the provisioner's own contract — the provider may never have created it. `--ignore-not-found` keeps that case on the success path so it stays distinguishable from a genuine kubectl failure.

##  Something to watch in CI

**This assertion may be flaky on GKE.** kube-dns there is managed by the addon manager, which can reconcile replica counts back up. If that happens, this check will fail — and that would be a real finding about the module rather than a bad test, but it needs a merge-queue run to know. The e2e suite only runs in the merge queue (`pr.yml` calls `lint.yml` only), so PR CI here exercises `cargo fmt`/`clippy` but not the new check.

Worth confirming against one AWS and one GCP merge-queue run before marking ready. Azure e2e is currently commented out in `merge_queue.yml`, so its names are unverified in practice.

Verified locally: `cargo fmt -- --check`, `cargo clippy -- -D warnings`, and `cargo build` all pass.