### PR TITLE
repo: force LF endings so a Windows clone works under WSL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Keep LF endings on checkout regardless of core.autocrlf, so that a clone made
+# on Windows still works when Terraform is run from WSL.
+#
+# The shell scripts are the reason this file exists: /bin/sh treats a trailing
+# CR as part of the token and fails with errors like `$'\r': command not found`.
+# Terraform's local-exec provisioners run them, so CRLF turns into an apply or
+# destroy failure rather than something caught at review time.
+*.sh text eol=lf
+
+# .tf files matter too, because heredoc bodies end up inside Kubernetes objects
+# — the CoreDNS module's Corefile is one — where stray CRs would be carried
+# through into the rendered config.
+*.tf text eol=lf

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Complete support for deploying Materialize on Google Cloud Platform with GKE, Cl
 - Cloud provider credentials configured
 - kubectl (for managing Kubernetes resources)
 - Appropriate cloud provider CLI tools (aws-cli, az, or gcloud)
+- Linux or macOS. Some modules clean up cloud resources through `local-exec`
+  provisioners, which Terraform runs with `/bin/sh` — unavailable when
+  Terraform runs from Windows directly, since it uses `cmd` there. On Windows,
+  run Terraform from WSL.
 
 ### Quick Start
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Complete support for deploying Materialize on Google Cloud Platform with GKE, Cl
 - Linux or macOS. Some modules clean up cloud resources through `local-exec`
   provisioners, which Terraform runs with `/bin/sh` — unavailable when
   Terraform runs from Windows directly, since it uses `cmd` there. On Windows,
-  run Terraform from WSL.
+  run Terraform from WSL (Best-Effort only).
 
 ### Quick Start
 


### PR DESCRIPTION
Came out of reviewing #301. Running Terraform from Windows directly has never worked for the modules that clean up cloud resources through `local-exec` — Terraform's default interpreter there is `cmd /C`, not `/bin/sh`, so none of those scripts can run whatever dialect they're written in. **WSL is the supported path on Windows**, and it mostly works already, because WSL is Linux.

What breaks it is line endings.

## The failure

A clone made on the Windows side with `core.autocrlf=true` rewrites the scripts to CRLF. `/bin/sh` then treats the trailing CR as part of the token:

```
$ sh crlf-script.sh
crlf-script.sh: line 2: set: -: invalid option
```

It dies on `set -eu` — the first line — so the script does nothing at all. And because these run inside provisioners, it surfaces as a failed `apply`/`destroy` rather than as something caught at review time.

## Verified, not assumed

Simulated a Windows clone of this repo (`git clone -c core.autocrlf=true`):

| Branch | `.sh` files on checkout |
|---|---|
| `main` | **CRLF** — would break `/bin/sh` |
| this branch | **LF** |

I also checked #301's branch: its newly extracted `eni-cleanup.sh` and `scale-down-deployment.sh` both come out **CRLF** on such a clone today, so this directly protects that PR.

## Scope

`*.tf` is included alongside `*.sh` because heredoc bodies end up inside Kubernetes objects — the CoreDNS module's `Corefile` is one — where stray CRs would be carried through into the rendered config.

**No churn:** every tracked `.sh` and `.tf` file is already LF (216 of them), so `git add --renormalize .` is a no-op. This only affects what future checkouts produce. `git check-attr` confirms the rules apply to `.tf`/`.sh` and leave `.rs`/`.md` alone.

Also records the Linux/macOS-or-WSL expectation in the prerequisites, since nothing stated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)