### PR TITLE
fix(ory-kratos): split the TLS deployment conditional so plan type-checks

### DIFF
--- a/kubernetes/modules/ory-kratos/main.tf
+++ b/kubernetes/modules/ory-kratos/main.tf
@@ -177,10 +177,12 @@ locals {
 
   deployment_config = length(local.tls_volumes) > 0 || length(local.upstream_oidc_extra_env) > 0 ? {
     deployment = merge(
-      length(local.tls_volumes) > 0 ? {
-        extraVolumes      = local.tls_volumes
-        extraVolumeMounts = local.tls_volume_mounts
-      } : {},
+      # One attribute per conditional: a multi-attribute object and {} cannot
+      # unify as a map when the attribute types differ, so a two-attribute
+      # branch fails with "Inconsistent conditional result types" as soon as
+      # TLS is enabled.
+      length(local.tls_volumes) > 0 ? { extraVolumes = local.tls_volumes } : {},
+      length(local.tls_volumes) > 0 ? { extraVolumeMounts = local.tls_volume_mounts } : {},
       length(local.upstream_oidc_extra_env) > 0 ? { extraEnv = local.upstream_oidc_extra_env } : {},
       length(local.upstream_oidc_env_annotations) > 0 ? { annotations = local.upstream_oidc_env_annotations } : {},
     )


### PR DESCRIPTION
## Problem

#338 assembles the Kratos Helm `deployment` block by merging conditionals, and the TLS entry builds two attributes in one conditional:

```hcl
length(local.tls_volumes) > 0 ? {
  extraVolumes      = local.tls_volumes
  extraVolumeMounts = local.tls_volume_mounts
} : {}
```

Terraform unifies `object` / `{}` conditional branches by falling back to a map, which requires every attribute to share one element type. `extraVolumes` and `extraVolumeMounts` have different element types, so the fallback is unavailable and any TLS-enabled instantiation fails at plan:

```
Error: Inconsistent conditional result types

  on kubernetes/modules/ory-kratos/main.tf line 180, in locals:
The true and false result expressions must have consistent types. The 'true'
value includes object attribute "extraVolumeMounts", which is absent in the
'false' value.
```

The error is value-dependent, so `terraform validate` does not catch it; it surfaces only when a root with `tls` configured plans the module. Hit by `MaterializeInc/mz-context-graph#338`, which pins ory-stack past de8ff35.

## Solution

One attribute per conditional, matching the `extraEnv` and `annotations` entries alongside — the single-attribute shape keeps the map fallback available. No behavior change: the merged result is identical whenever TLS is enabled, and both attributes still appear or disappear together.

## Testing

- Reproduced the plan failure on a standalone root with the current expression; the split expression plans clean with all four keys present in the merged `deployment` block.
- `terraform validate` and `terraform fmt -check` on `ory-kratos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)