### PR TITLE
Bump to helm-chart v26.35.0

### DIFF
--- a/aws/modules/operator/README.md
+++ b/aws/modules/operator/README.md
@@ -54,7 +54,7 @@ No modules.
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for all resource names (replaces separate namespace and environment variables) | `string` | n/a | yes |
 | <a name="input_operator_namespace"></a> [operator\_namespace](#input\_operator\_namespace) | Namespace for the Materialize operator | `string` | `"materialize"` | no |
 | <a name="input_operator_node_selector"></a> [operator\_node\_selector](#input\_operator\_node\_selector) | Node selector for operator pods and metrics-server. | `map(string)` | `{}` | no |
-| <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | Version of the Materialize operator to install | `string` | `"v26.34.1"` | no |
+| <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | Version of the Materialize operator to install | `string` | `"v26.35.0"` | no |
 | <a name="input_orchestratord_version"></a> [orchestratord\_version](#input\_orchestratord\_version) | Version of the Materialize orchestrator to install | `string` | `null` | no |
 | <a name="input_swap_enabled"></a> [swap\_enabled](#input\_swap\_enabled) | Whether to enable swap on the local NVMe disks. | `bool` | `true` | no |
 | <a name="input_tolerations"></a> [tolerations](#input\_tolerations) | Tolerations for operator pods and metrics-server. | <pre>list(object({<br/>    key      = string<br/>    value    = optional(string)<br/>    operator = optional(string, "Equal")<br/>    effect   = string<br/>  }))</pre> | `[]` | no |

--- a/aws/modules/operator/variables.tf
+++ b/aws/modules/operator/variables.tf
@@ -7,7 +7,7 @@ variable "name_prefix" {
 variable "operator_version" {
   description = "Version of the Materialize operator to install"
   type        = string
-  default     = "v26.34.1" # META: helm-chart version
+  default     = "v26.35.0" # META: helm-chart version
   nullable    = false
 }
 

--- a/azure/modules/operator/README.md
+++ b/azure/modules/operator/README.md
@@ -51,7 +51,7 @@ No modules.
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for all resource names (replaces separate namespace and environment variables) | `string` | n/a | yes |
 | <a name="input_operator_namespace"></a> [operator\_namespace](#input\_operator\_namespace) | Namespace for the Materialize operator | `string` | `"materialize"` | no |
 | <a name="input_operator_node_selector"></a> [operator\_node\_selector](#input\_operator\_node\_selector) | Node selector for operator pods and metrics-server. | `map(string)` | `{}` | no |
-| <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | Version of the Materialize operator to install | `string` | `"v26.34.1"` | no |
+| <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | Version of the Materialize operator to install | `string` | `"v26.35.0"` | no |
 | <a name="input_orchestratord_version"></a> [orchestratord\_version](#input\_orchestratord\_version) | Version of the Materialize orchestrator to install | `string` | `null` | no |
 | <a name="input_swap_enabled"></a> [swap\_enabled](#input\_swap\_enabled) | Whether to enable swap on the local NVMe disks. | `bool` | `true` | no |
 | <a name="input_tolerations"></a> [tolerations](#input\_tolerations) | Tolerations for operator pods and metrics-server. | <pre>list(object({<br/>    key      = string<br/>    value    = optional(string)<br/>    operator = optional(string, "Equal")<br/>    effect   = string<br/>  }))</pre> | `[]` | no |

--- a/azure/modules/operator/variables.tf
+++ b/azure/modules/operator/variables.tf
@@ -7,7 +7,7 @@ variable "name_prefix" {
 variable "operator_version" {
   description = "Version of the Materialize operator to install"
   type        = string
-  default     = "v26.34.1" # META: helm-chart version
+  default     = "v26.35.0" # META: helm-chart version
   nullable    = false
 }
 

--- a/gcp/modules/operator/README.md
+++ b/gcp/modules/operator/README.md
@@ -57,7 +57,7 @@ No modules.
 | <a name="input_operator_namespace"></a> [operator\_namespace](#input\_operator\_namespace) | Namespace for the Materialize operator | `string` | `"materialize"` | no |
 | <a name="input_operator_node_selector"></a> [operator\_node\_selector](#input\_operator\_node\_selector) | Node selector for operator pods and metrics-server. | `map(string)` | `{}` | no |
 | <a name="input_operator_service_account_annotations"></a> [operator\_service\_account\_annotations](#input\_operator\_service\_account\_annotations) | Annotations to add to the operator's Kubernetes service account, e.g. iam.gke.io/gcp-service-account to link it to a GCP service account via workload identity (required for enable\_node\_upgrade\_rollout\_trigger). | `map(string)` | `{}` | no |
-| <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | Version of the Materialize operator to install | `string` | `"v26.34.1"` | no |
+| <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | Version of the Materialize operator to install | `string` | `"v26.35.0"` | no |
 | <a name="input_orchestratord_version"></a> [orchestratord\_version](#input\_orchestratord\_version) | Version of the Materialize orchestrator to install | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region/Zone for the operator Helm values. | `string` | n/a | yes |
 | <a name="input_swap_enabled"></a> [swap\_enabled](#input\_swap\_enabled) | Whether to enable swap on the local NVMe disks. | `bool` | `true` | no |

--- a/gcp/modules/operator/variables.tf
+++ b/gcp/modules/operator/variables.tf
@@ -7,7 +7,7 @@ variable "name_prefix" {
 variable "operator_version" {
   description = "Version of the Materialize operator to install"
   type        = string
-  default     = "v26.34.1" # META: helm-chart version
+  default     = "v26.35.0" # META: helm-chart version
   nullable    = false
 }
 

--- a/kubernetes/modules/materialize-instance/README.md
+++ b/kubernetes/modules/materialize-instance/README.md
@@ -48,7 +48,7 @@ No modules.
 | <a name="input_enable_rbac"></a> [enable\_rbac](#input\_enable\_rbac) | Enable role-based access control (sets spec.enableRbac on the Materialize CR). Defaults to true for a secure-by-default posture. When false, the operator launches environmentd with enable\_rbac\_checks=false and privilege checks are not enforced. | `bool` | `true` | no |
 | <a name="input_environmentd_extra_args"></a> [environmentd\_extra\_args](#input\_environmentd\_extra\_args) | Extra command line arguments for environmentd | `list(string)` | `[]` | no |
 | <a name="input_environmentd_extra_env"></a> [environmentd\_extra\_env](#input\_environmentd\_extra\_env) | Extra environment variables for environmentd | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
-| <a name="input_environmentd_version"></a> [environmentd\_version](#input\_environmentd\_version) | Version of environmentd to use | `string` | `"v26.34.1"` | no |
+| <a name="input_environmentd_version"></a> [environmentd\_version](#input\_environmentd\_version) | Version of environmentd to use | `string` | `"v26.35.0"` | no |
 | <a name="input_external_login_password_mz_system"></a> [external\_login\_password\_mz\_system](#input\_external\_login\_password\_mz\_system) | Password for external login to mz\_system. Must be set if authenticator\_kind is 'Password', 'Sasl', or 'Oidc'. | `string` | `null` | no |
 | <a name="input_force_rollout"></a> [force\_rollout](#input\_force\_rollout) | UUID to force a rollout | `string` | `"00000000-0000-0000-0000-000000000001"` | no |
 | <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | Name of the Materialize instance | `string` | n/a | yes |

--- a/kubernetes/modules/materialize-instance/variables.tf
+++ b/kubernetes/modules/materialize-instance/variables.tf
@@ -53,7 +53,7 @@ variable "license_key" {
 variable "environmentd_version" {
   description = "Version of environmentd to use"
   type        = string
-  default     = "v26.34.1" # META: mz version
+  default     = "v26.35.0" # META: mz version
   nullable    = false
 }
 


### PR DESCRIPTION
Auto bump failed in https://buildkite.com/materialize/publish-helm-charts/builds/183#019fb87a-0264-4607-8807-f922baf10991, fixed by https://github.com/MaterializeInc/materialize/pull/38038 for the future.