### PR TITLE
Set floor of terraform >= 1.10; update CI to use latest TF

### DIFF
--- a/.github/setup/aws/versions.tf
+++ b/.github/setup/aws/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/.github/setup/azure/versions.tf
+++ b/.github/setup/azure/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     azurerm = {

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: "1.9.0"
+          terraform_version: "1.15.8"
 
       - name: Terraform Format Check
         run: terraform fmt -check -recursive
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: "1.9.0"
+          terraform_version: "1.15.8"
 
       - name: Check if example exists
         id: check-dir

--- a/.github/workflows/test-aws.yml
+++ b/.github/workflows/test-aws.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: "1.9.0"
+          terraform_version: "1.15.8"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test-azure.yml
+++ b/.github/workflows/test-azure.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: "1.9.0"
+          terraform_version: "1.15.8"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test-gcp.yml
+++ b/.github/workflows/test-gcp.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: "1.9.0"
+          terraform_version: "1.15.8"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Complete support for deploying Materialize on Google Cloud Platform with GKE, Cl
 
 ### Prerequisites
 
-- Terraform >= 1.0
+- Terraform >= 1.10
 - Cloud provider credentials configured
 - kubectl (for managing Kubernetes resources)
 - Appropriate cloud provider CLI tools (aws-cli, az, or gcloud)
@@ -204,6 +204,12 @@ The GCP examples now default `region` to `us-east1` (previously `us-central1`), 
 - If you already pass `region` explicitly (including all consumers of `gcp/modules/*`), there is no impact.
 - To actually move an existing deployment to `us-east1`, treat it as a new deployment plus a data migration. GCP cannot relocate these resources in place, so there is no in-place `terraform apply` path between regions.
 - `gcp/README.md`'s `node_locations` examples now use `us-east1-b` and `us-east1-d`. `node_locations` must name zones inside the cluster's region. The module only regex-checks the `region-zone` string shape, so copies of the old `us-central1-*` examples pass `terraform validate` and `plan` and then fail at apply from the GKE API. Note `us-east1` has no `-a` zone.
+
+##### Minimum Terraform Version
+
+The default floor of terraform is now 1.10 which was released before 2025-01-01.
+This fixes some buggy behavior with source references that contain a `/` in the tag name.
+The recommended version remains any stable version of terraform: 1.14 and 1.15 at this time.
 
 #### v8.0.0
 

--- a/aws/examples/enterprise/versions.tf
+++ b/aws/examples/enterprise/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/examples/migration/versions.tf
+++ b/aws/examples/migration/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/examples/simple/versions.tf
+++ b/aws/examples/simple/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/modules/aws-lbc/README.md
+++ b/aws/modules/aws-lbc/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |

--- a/aws/modules/aws-lbc/versions.tf
+++ b/aws/modules/aws-lbc/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/modules/database/README.md
+++ b/aws/modules/database/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 
 ## Providers

--- a/aws/modules/database/versions.tf
+++ b/aws/modules/database/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/modules/ebs-csi-driver/README.md
+++ b/aws/modules/ebs-csi-driver/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.5.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0, < 2.39.0 |

--- a/aws/modules/ebs-csi-driver/versions.tf
+++ b/aws/modules/ebs-csi-driver/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/modules/eks-node-group/README.md
+++ b/aws/modules/eks-node-group/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
 

--- a/aws/modules/eks-node-group/versions.tf
+++ b/aws/modules/eks-node-group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.4"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/modules/eks/README.md
+++ b/aws/modules/eks/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |

--- a/aws/modules/eks/versions.tf
+++ b/aws/modules/eks/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/modules/karpenter-ec2nodeclass/README.md
+++ b/aws/modules/karpenter-ec2nodeclass/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 | <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |

--- a/aws/modules/karpenter-ec2nodeclass/versions.tf
+++ b/aws/modules/karpenter-ec2nodeclass/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/modules/karpenter-nodepool/README.md
+++ b/aws/modules/karpenter-nodepool/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 | <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |

--- a/aws/modules/karpenter-nodepool/versions.tf
+++ b/aws/modules/karpenter-nodepool/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/modules/karpenter/README.md
+++ b/aws/modules/karpenter/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 | <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |

--- a/aws/modules/karpenter/versions.tf
+++ b/aws/modules/karpenter/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/modules/networking/README.md
+++ b/aws/modules/networking/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 
 ## Providers

--- a/aws/modules/networking/versions.tf
+++ b/aws/modules/networking/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/modules/nlb/README.md
+++ b/aws/modules/nlb/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 2.4.1 |

--- a/aws/modules/nlb/target/README.md
+++ b/aws/modules/nlb/target/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 2.4.1 |

--- a/aws/modules/nlb/target/versions.tf
+++ b/aws/modules/nlb/target/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/modules/nlb/versions.tf
+++ b/aws/modules/nlb/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/modules/operator/README.md
+++ b/aws/modules/operator/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 | <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |

--- a/aws/modules/operator/versions.tf
+++ b/aws/modules/operator/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/modules/storage/README.md
+++ b/aws/modules/storage/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0, < 3.10.0 |
 

--- a/aws/modules/storage/versions.tf
+++ b/aws/modules/storage/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/aws/modules/vpc-cni/README.md
+++ b/aws/modules/vpc-cni/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0, < 5.101.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.5.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0, < 2.39.0 |

--- a/aws/modules/vpc-cni/versions.tf
+++ b/aws/modules/vpc-cni/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.4.0"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/azure/examples/enterprise/versions.tf
+++ b/azure/examples/enterprise/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     azurerm = {

--- a/azure/examples/migration/README.md
+++ b/azure/examples/migration/README.md
@@ -8,7 +8,7 @@ Migrate from the old `azure-old/` monolithic module to the new `materialize-terr
 
 ## Quick Start
 
-**Prerequisites:** Terraform CLI (>= 1.8), Python 3.7+, Azure CLI, kubectl, access to your old Terraform state
+**Prerequisites:** Terraform CLI (>= 1.10), Python 3.7+, Azure CLI, kubectl, access to your old Terraform state
 
 ```bash
 # CRITICAL: Verify old state access first

--- a/azure/examples/migration/versions.tf
+++ b/azure/examples/migration/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     azurerm = {

--- a/azure/examples/simple/versions.tf
+++ b/azure/examples/simple/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     azurerm = {

--- a/azure/modules/aks/README.md
+++ b/azure/modules/aks/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0, < 4.76.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5, < 3.10.0 |
 

--- a/azure/modules/aks/versions.tf
+++ b/azure/modules/aks/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     azurerm = {

--- a/azure/modules/database/README.md
+++ b/azure/modules/database/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.75.0, < 4.76.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0, < 3.10.0 |
 

--- a/azure/modules/database/versions.tf
+++ b/azure/modules/database/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     azurerm = {

--- a/azure/modules/load_balancers/README.md
+++ b/azure/modules/load_balancers/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 2.45.0, < 3.10.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.75.0, < 4.76.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |

--- a/azure/modules/load_balancers/versions.tf
+++ b/azure/modules/load_balancers/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
 

--- a/azure/modules/networking/README.md
+++ b/azure/modules/networking/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0, < 4.76.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5, < 3.10.0 |
 

--- a/azure/modules/networking/versions.tf
+++ b/azure/modules/networking/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     azurerm = {

--- a/azure/modules/nodepool/README.md
+++ b/azure/modules/nodepool/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0, < 4.76.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0, < 2.39.0 |
 

--- a/azure/modules/nodepool/versions.tf
+++ b/azure/modules/nodepool/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     azurerm = {

--- a/azure/modules/operator/README.md
+++ b/azure/modules/operator/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |

--- a/azure/modules/operator/versions.tf
+++ b/azure/modules/operator/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     kubernetes = {

--- a/azure/modules/storage/README.md
+++ b/azure/modules/storage/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.75.0, < 4.76.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.3.4, < 2.5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.0, < 3.10.0 |

--- a/azure/modules/storage/versions.tf
+++ b/azure/modules/storage/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     azurerm = {

--- a/gcp/examples/enterprise/versions.tf
+++ b/gcp/examples/enterprise/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     google = {

--- a/gcp/examples/migration/README.md
+++ b/gcp/examples/migration/README.md
@@ -8,7 +8,7 @@ Migrate from the old `gcp-old/` monolithic module to the new `materialize-terraf
 
 ## Quick Start
 
-**Prerequisites:** Terraform CLI (>= 1.8), Python 3.7+, gcloud CLI, kubectl, access to your old Terraform state
+**Prerequisites:** Terraform CLI (>= 1.10), Python 3.7+, gcloud CLI, kubectl, access to your old Terraform state
 
 ```bash
 # CRITICAL: Verify old state access first
@@ -131,7 +131,7 @@ See `terraform.tfvars.example` for the full list with inline documentation and g
 | Aspect | Old Module | New Module | Migration Impact |
 |--------|-----------|------------|------------------|
 | **Structure** | Monolithic (`gcp-old/`) | Modular (`gcp/modules/*` + `kubernetes/modules/*`) | State paths change |
-| **Terraform** | `>= 1.0` | `>= 1.8` | Terraform version bump |
+| **Terraform** | `>= 1.0` | `>= 1.10` | Terraform version bump |
 | **Google Provider** | `>= 6.0` | `>= 6.31, < 7` | Tighter version constraint |
 | **Networking** | Direct resources (VPC, subnet, route) | `terraform-google-modules/network/google` + Cloud NAT | Migration keeps old resources inline |
 | **GKE** | Basic cluster + system node pool | Adds private_cluster_config, master_authorized_networks, L4 LB subsetting | Migration keeps old config inline |

--- a/gcp/examples/migration/versions.tf
+++ b/gcp/examples/migration/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     google = {

--- a/gcp/examples/simple/versions.tf
+++ b/gcp/examples/simple/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     google = {

--- a/gcp/modules/database/README.md
+++ b/gcp/modules/database/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.22, < 8 |
 
 ## Providers

--- a/gcp/modules/database/versions.tf
+++ b/gcp/modules/database/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     google = {

--- a/gcp/modules/gke/README.md
+++ b/gcp/modules/gke/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.22, < 8 |
 
 ## Providers

--- a/gcp/modules/gke/versions.tf
+++ b/gcp/modules/gke/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     google = {

--- a/gcp/modules/load_balancers/README.md
+++ b/gcp/modules/load_balancers/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.22, < 8 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
 

--- a/gcp/modules/load_balancers/versions.tf
+++ b/gcp/modules/load_balancers/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     kubernetes = {

--- a/gcp/modules/networking/README.md
+++ b/gcp/modules/networking/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.22, < 8 |
 
 ## Providers

--- a/gcp/modules/networking/versions.tf
+++ b/gcp/modules/networking/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     google = {

--- a/gcp/modules/nodepool/README.md
+++ b/gcp/modules/nodepool/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.22, < 8 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 7.22, < 8 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0, < 2.39.0 |

--- a/gcp/modules/nodepool/versions.tf
+++ b/gcp/modules/nodepool/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     google = {

--- a/gcp/modules/operator/README.md
+++ b/gcp/modules/operator/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |

--- a/gcp/modules/operator/versions.tf
+++ b/gcp/modules/operator/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     kubernetes = {

--- a/gcp/modules/storage/README.md
+++ b/gcp/modules/storage/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.22, < 8 |
 
 ## Providers

--- a/gcp/modules/storage/versions.tf
+++ b/gcp/modules/storage/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     google = {

--- a/kubernetes/modules/cert-manager/README.md
+++ b/kubernetes/modules/cert-manager/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.5.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0, < 2.39.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1, < 3.10.0 |

--- a/kubernetes/modules/cert-manager/versions.tf
+++ b/kubernetes/modules/cert-manager/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.10"
 
   required_providers {
     kubernetes = {

--- a/kubernetes/modules/coredns/README.md
+++ b/kubernetes/modules/coredns/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0, < 3.4.0 |
 

--- a/kubernetes/modules/coredns/versions.tf
+++ b/kubernetes/modules/coredns/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/kubernetes/modules/grafana/README.md
+++ b/kubernetes/modules/grafana/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.5.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0, < 2.39.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0, < 3.10.0 |

--- a/kubernetes/modules/grafana/versions.tf
+++ b/kubernetes/modules/grafana/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.10"
 
   required_providers {
     kubernetes = {

--- a/kubernetes/modules/hpa/README.md
+++ b/kubernetes/modules/hpa/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
 
 ## Providers

--- a/kubernetes/modules/hpa/versions.tf
+++ b/kubernetes/modules/hpa/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/kubernetes/modules/materialize-instance/README.md
+++ b/kubernetes/modules/materialize-instance/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 2.4.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0, < 2.39.0 |
 

--- a/kubernetes/modules/materialize-instance/versions.tf
+++ b/kubernetes/modules/materialize-instance/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     kubernetes = {

--- a/kubernetes/modules/node-local-dns/README.md
+++ b/kubernetes/modules/node-local-dns/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.5.0, < 2.18.0 |
 
 ## Providers

--- a/kubernetes/modules/node-local-dns/versions.tf
+++ b/kubernetes/modules/node-local-dns/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.10"
 
   required_providers {
     helm = {

--- a/kubernetes/modules/ory-hydra/README.md
+++ b/kubernetes/modules/ory-hydra/README.md
@@ -11,7 +11,7 @@ keys: https://github.com/ory/k8s/blob/master/helm/charts/hydra/values.yaml
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |

--- a/kubernetes/modules/ory-hydra/versions.tf
+++ b/kubernetes/modules/ory-hydra/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     kubernetes = {

--- a/kubernetes/modules/ory-kratos/README.md
+++ b/kubernetes/modules/ory-kratos/README.md
@@ -11,7 +11,7 @@ keys: https://github.com/ory/k8s/blob/master/helm/charts/kratos/values.yaml
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0, < 1.4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0, < 2.18.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |

--- a/kubernetes/modules/ory-kratos/versions.tf
+++ b/kubernetes/modules/ory-kratos/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     kubernetes = {

--- a/kubernetes/modules/ory-polis/README.md
+++ b/kubernetes/modules/ory-polis/README.md
@@ -22,7 +22,7 @@ helm show values oci://ory.registry.cloud.materialize.com/ory-artifacts/helm-oel
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |

--- a/kubernetes/modules/ory-polis/versions.tf
+++ b/kubernetes/modules/ory-polis/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     kubernetes = {

--- a/kubernetes/modules/ory-selfservice-ui/README.md
+++ b/kubernetes/modules/ory-selfservice-ui/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, < 2.39.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0, < 3.10.0 |
 

--- a/kubernetes/modules/ory-selfservice-ui/versions.tf
+++ b/kubernetes/modules/ory-selfservice-ui/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     kubernetes = {

--- a/kubernetes/modules/ory-stack/README.md
+++ b/kubernetes/modules/ory-stack/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_deepmerge"></a> [deepmerge](#requirement\_deepmerge) | ~> 1.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 2.4.1 |

--- a/kubernetes/modules/ory-stack/versions.tf
+++ b/kubernetes/modules/ory-stack/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/kubernetes/modules/ory-talos/README.md
+++ b/kubernetes/modules/ory-talos/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 

--- a/kubernetes/modules/ory-talos/versions.tf
+++ b/kubernetes/modules/ory-talos/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8"
+  required_version = ">= 1.10"
 
   required_providers {
     kubernetes = {

--- a/kubernetes/modules/self-signed-cluster-issuer/README.md
+++ b/kubernetes/modules/self-signed-cluster-issuer/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.5.0, < 2.18.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 2.4.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10.0, < 2.39.0 |

--- a/kubernetes/modules/self-signed-cluster-issuer/versions.tf
+++ b/kubernetes/modules/self-signed-cluster-issuer/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.10"
 
   required_providers {
     kubernetes = {

--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,22 @@
   "labels": [
     "regenerate-docs",
     "dependencies"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Keep the Terraform CLI that hashicorp/setup-terraform installs in sync with the latest release. Every workflow pins the same exact version, and nothing else updates it — the github-actions manager only maintains the `uses:` ref, not the action's inputs, so without this the CLI silently ages while the actions around it stay current. Matched by key name rather than by a `# renovate:` annotation so that a newly added workflow is covered without anyone remembering to annotate it.",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/[^/]+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "terraform_version:\\s*[\"'](?<currentValue>[^\"'\\s]+)[\"']"
+      ],
+      "depNameTemplate": "terraform",
+      "packageNameTemplate": "hashicorp/terraform",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)$",
+      "versioningTemplate": "semver"
+    }
   ]
 }

--- a/test/README.md
+++ b/test/README.md
@@ -5,7 +5,7 @@ End-to-end integration tests for the Materialize self-managed Terraform modules.
 ## Prerequisites
 
 - Rust (edition 2024)
-- Terraform >= 1.8
+- Terraform >= 1.10
 - `psql` (PostgreSQL client)
 - Cloud CLI for your provider:
   - **AWS**: `aws` CLI, configured profile


### PR DESCRIPTION
This fixes a bug in 1.9 that our CI was running by simply changing the floor to a more recent version.
We recommend only the supported/stable versions of terraform (1.14 and 1.15) but it is easy to fall behind with a fast release cycle.
Our CI has moved to 1.15 and is now managed by renovate.