### PR TITLE
ory-stack: lock down Kratos self-service for SSO-only deployments

### DIFF
--- a/kubernetes/modules/ory-stack/main.tf
+++ b/kubernetes/modules/ory-stack/main.tf
@@ -126,6 +126,13 @@ locals {
         }
         selfservice = {
           default_browser_return_url = local.ui_external_url
+          # SSO-only: disable local password login/registration and profile
+          # self-edits so users cannot set their own traits (e.g. groups).
+          # OIDC stays enabled, so IdP just-in-time provisioning still works.
+          methods = {
+            password = { enabled = false }
+            profile  = { enabled = false }
+          }
           flows = {
             login = { ui_url = "${local.ui_external_url}/login" }
             # session hook logs the user in on first OIDC registration; without


### PR DESCRIPTION
Security fix for the SSO-only enterprise stack. Disables the Kratos password and profile self-service methods so users can only arrive through the upstream IdP and cannot self-register or edit their own identity traits. OIDC just-in-time provisioning is unaffected. Callers can override via `kratos_helm_values` if needed.