### PR TITLE
ci: fix stray line continuation that broke the tag workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -e \
+          set -euo pipefail
           latest=$(gh api --paginate "repos/$GITHUB_REPOSITORY/tags" --jq '.[].name' \
             | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
           echo "Latest release: $latest"


### PR DESCRIPTION
## Problem

The tag workflow added in #320 has never created a release. Every run since 2026-07-27 completed "successfully" in ~10s without tagging anything.

Root cause: a trailing backslash on `set -e \` merged it with the next line, making the whole thing one command:

```bash
set -e latest=$(gh api ...)
```

`latest=...` became a positional argument to `set` instead of a variable assignment, so `$latest` was always empty. The compare API call then failed, but its failure was swallowed by the `| while` pipeline, leaving `prs` empty → no bump → the script hit the "no version label" branch and exited 0. Run logs confirm:

```
Latest release: 
No version label on any PR merged since , not creating a release
```

## Fix

- Remove the stray backslash so `set` and the assignment are separate statements.
- Use `set -euo pipefail` so pipeline failures (e.g. the `gh api` calls feeding the while loop) fail the run visibly instead of silently producing empty output.

## Note on the first release after merge

Once merged, the next push to main will release everything accumulated since v8.0.1 (2026-07-23) in one version. The highest bump label across all of those PRs wins, so expect a minor or major jump rather than a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)