### PR TITLE
Make --environmentd-version actually take effect

### DIFF
--- a/test/src/commands/init.rs
+++ b/test/src/commands/init.rs
@@ -328,22 +328,14 @@ pub(crate) async fn inject_dev_overrides(dest: &Path, overrides: &DevOverrides) 
     if !operator_vars.is_empty() {
         let module = find_module_mut(&mut body, "operator")?;
         for &key in &operator_vars {
-            if !module.body.has_attribute(key) {
-                module.body.push(module_var_attr(key));
-                changed = true;
-                println!("  Injected {key} into operator module in main.tf");
-            }
+            changed |= set_module_var(module, "operator", key);
         }
     }
 
     // Materialize instance module: environmentd_version
     if overrides.environmentd_version {
         let module = find_module_mut(&mut body, "materialize_instance")?;
-        if !module.body.has_attribute("environmentd_version") {
-            module.body.push(module_var_attr("environmentd_version"));
-            changed = true;
-            println!("  Injected environmentd_version into materialize_instance module in main.tf");
-        }
+        changed |= set_module_var(module, "materialize_instance", "environmentd_version");
     }
 
     if changed {
@@ -351,6 +343,37 @@ pub(crate) async fn inject_dev_overrides(dest: &Path, overrides: &DevOverrides) 
     }
 
     Ok(())
+}
+
+/// Points `<key>` at `var.<key>` in the given module block, replacing whatever
+/// value is already there.
+///
+/// The examples wire some of these attributes to a different variable of their
+/// own -- every simple example has `environmentd_version = var.materialize_version`
+/// -- so an injection that skipped when the attribute was already present left
+/// the dev override silently unused: the variable was declared in
+/// `dev_variables.tf` and set in `terraform.tfvars.json`, but nothing read it,
+/// and terraform does not warn about a declared-but-unreferenced variable. The
+/// run then came up on the module's default version.
+///
+/// Returns whether the module block was modified.
+fn set_module_var(module: &mut hcl_edit::structure::Block, module_name: &str, key: &str) -> bool {
+    let want = format!("var.{key}");
+
+    let Some(mut attr) = module.body.get_attribute_mut(key) else {
+        module.body.push(module_var_attr(key));
+        println!("  Injected {key} into {module_name} module in main.tf");
+        return true;
+    };
+
+    let current = attr.value_mut().to_string();
+    let current = current.trim();
+    if current == want {
+        return false;
+    }
+    println!("  Repointed {key} from {current} to {want} in {module_name} module in main.tf");
+    *attr.value_mut() = var_ref(key);
+    true
 }
 
 /// Finds a `module "<name>"` block in the body, returning a mutable reference.

--- a/test/src/commands/verify.rs
+++ b/test/src/commands/verify.rs
@@ -39,6 +39,11 @@ pub async fn phase_verify(dir: &Path) -> Result<()> {
         println!("\nVerifying pods in namespace {instance_namespace}...");
         verify_pods_running(&kubeconfig, instance_namespace).await?;
 
+        if let Some(version) = tfvars.common().environmentd_version.as_deref() {
+            println!("\nVerifying environmentd is running version {version}...");
+            verify_environmentd_image(&kubeconfig, instance_namespace, version).await?;
+        }
+
         println!("\nVerifying node-local-dns...");
         verify_node_local_dns(&kubeconfig, provider).await?;
 
@@ -273,7 +278,55 @@ async fn check_expected_pods(kubeconfig: &Path, namespace: &str) -> Result<()> {
     }
 
     for (name, phase) in &pods {
-        println!("  [ok] {name}: {phase}");
+        // Pods outside EXPECTED_PODS, and surplus pods of an expected type
+        // (e.g. the incoming ReplicaSet during a rollout), are listed but do
+        // not gate the check -- so only mark the Running ones ok.
+        let mark = if *phase == "Running" { "ok" } else { "--" };
+        println!("  [{mark}] {name}: {phase}");
+    }
+    Ok(())
+}
+
+/// Asserts that the running environmentd pods use the image tag requested via
+/// `--environmentd-version`.
+///
+/// Without this, an override that fails to reach the terraform module leaves
+/// the run on the module's default version and every other check still passes,
+/// so a test of a specific build silently becomes a test of a different one.
+async fn verify_environmentd_image(
+    kubeconfig: &Path,
+    namespace: &str,
+    expected_version: &str,
+) -> Result<()> {
+    let output = run_cmd_output(kubectl(kubeconfig).args([
+        "get",
+        "pods",
+        "-n",
+        namespace,
+        "-o",
+        "jsonpath={range .items[*]}{.metadata.name} {.status.phase} {.spec.containers[0].image}{'\\n'}{end}",
+    ]))
+    .await?;
+
+    let expected_suffix = format!(":{expected_version}");
+    let mut checked = 0;
+    for line in output.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        let [name, phase, image] = parts[..] else {
+            continue;
+        };
+        if !name.contains("environmentd") || phase != "Running" {
+            continue;
+        }
+        if !image.ends_with(&expected_suffix) {
+            bail!("{name} runs image {image}, expected version {expected_version}");
+        }
+        println!("  [ok] {name}: {image}");
+        checked += 1;
+    }
+
+    if checked == 0 {
+        bail!("found no running environmentd pod to check the image version of");
     }
     Ok(())
 }


### PR DESCRIPTION
### Motivation

`cargo run -- init|run <provider> --environmentd-version <tag>` silently deployed the module's default version instead of the requested one, on all three providers.

`inject_dev_overrides` only added `environmentd_version = var.environmentd_version` to the `materialize_instance` module when the attribute was **absent**:

```rust
if !module.body.has_attribute("environmentd_version") {
    module.body.push(module_var_attr("environmentd_version"));
```

But every simple example already sets it — `aws/examples/simple/main.tf:503`, `azure/examples/simple/main.tf:398`, `gcp/examples/simple/main.tf:471` all have `environmentd_version = var.materialize_version`. So the injection was a no-op, `var.environmentd_version` was declared in `dev_variables.tf` and set in `terraform.tfvars.json` with nothing referencing it, and terraform doesn't warn about a declared-but-unused variable.

Found while testing MaterializeInc/materialize#38178 against a PR build: `verify` reported "All verifications passed!" on a cluster running `materialize/environmentd:v26.36.0` rather than the requested build. The run was worthless and nothing said so.

### Changes

* Replace the skip-if-present injection with `set_module_var`, which repoints an existing attribute at `var.<key>` and logs what it changed. Attributes already pointing at `var.<key>` are left alone, so repeated `sync`s don't rewrite `main.tf`.
* `verify` now asserts the running environmentd image matches `environmentd_version` when it's set — the check that would have caught this, since every other check passed against the wrong image.
* Stop printing `[ok]` next to pods that aren't `Running`. The gate was correct (a minimum count of `Running` pods per type); only the summary line was wrong, labelling e.g. a rollout's incoming `Pending` ReplicaSet as `[ok]`.

`--orchestratord-version` was never affected: the operator module takes `operator_version` (chart) and `orchestratord_version` (image tag) as separate variables, so that injection had nothing to collide with.

### Testing

Ran `sync` against a live Azure test run, which re-copies the pristine example and re-applies the overrides — exactly the path that failed:

```
Re-applying dev overrides...
  Repointed environmentd_version from var.materialize_version to var.environmentd_version in materialize_instance module in main.tf
```

`terraform validate` passes on the resulting run directory, and `cargo fmt --check` / `cargo clippy -- -D warnings` are clean. The harness has no unit tests, so I didn't add a test module for one function; happy to if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)