### PR TITLE
CLO-213: Run self-managed module tests locally on kind

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,7 @@ jobs:
           - "aws/examples/simple"
           - "azure/examples/simple"
           - "gcp/examples/simple"
+          - "kubernetes/examples/simple"
       fail-fast: false
     steps:
       - name: Checkout code

--- a/.github/workflows/test-kind.yml
+++ b/.github/workflows/test-kind.yml
@@ -1,0 +1,60 @@
+name: Kind Tests
+
+# Self-managed Materialize on a local kind cluster. Needs no cloud
+# credentials, only the MATERIALIZE_LICENSE_KEY secret. Manually
+# dispatchable for now; wiring into the merge queue is deferred until the
+# workflow has proven reliable.
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read # Required to checkout code
+
+jobs:
+  test-kind:
+    name: Kind Infrastructure Tests
+    # A larger runner: the stack's default resource requests (1 CPU / 4Gi
+    # for environmentd alone) do not fit the standard 4-CPU runner.
+    runs-on: ubuntu-24.04-16core
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: "1.15.8"
+
+      - name: Install kind
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          install_only: true
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            test/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('test/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build tests
+        working-directory: test
+        run: cargo build
+
+      - name: Run Kind Tests
+        working-directory: test
+        env:
+          MATERIALIZE_LICENSE_KEY: ${{ secrets.MATERIALIZE_LICENSE_KEY }}
+        run: |
+          cargo run -- run --destroy-on-failure kind \
+            --owner "github-actions"

--- a/kubernetes/examples/simple/.terraform.lock.hcl
+++ b/kubernetes/examples/simple/.terraform.lock.hcl
@@ -1,0 +1,84 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/alekc/kubectl" {
+  version     = "2.4.1"
+  constraints = "2.4.1"
+  hashes = [
+    "h1:pDnerh94NFiSv5z/Vuq+c1mEdn117P9KQI8zXeEEAEI=",
+    "zh:00a27c51a6f1082f20cbee52e0b996e4bed1dbc90de682cc309618aee2857e35",
+    "zh:16f94d63152a8a7c637fa3c609a104416272565b7a9b620e3b895ddb9912e288",
+    "zh:18a5c663c2aa6e673d75650d27888f1f91894f46d504fbf4a87f045c96f7afc1",
+    "zh:1a7c76db49ec94c0669baa6e416007f76acf09dbd141ef20036e4e13840651d7",
+    "zh:2baf0f93ff27fa0ff7265ee9eed5cc773311ace3bf936eb72bfbbd579d436894",
+    "zh:3ea7f773485b08ed55eedd29a7c83988c91ba2cc346b2436e7d1347ab061625a",
+    "zh:4bb3a241078f7b62dc41e9ac156c83b628933248b76cee3ec0d0264c0a2a25b7",
+    "zh:57571e1d9230fbde986a265228e17662eeb5ec63c12b84742564d453ad21f955",
+    "zh:6e1b82fde0037368a9e156304a580364ef926f26ffe235bb5a67b4c9f2edc2c4",
+    "zh:9dec7ed91b39d9815d9c37b78eca0327f631c66b2bcc61cbb4212c6d2ec76a22",
+    "zh:a347aebd398769c35ed2d3169025a7a11c1937d94efead7a7bee212aabba1c73",
+    "zh:b74e24ec0e2e176ee6cc18f33ac7e3609cfd6ca377b49cbd64b0f36edbb54342",
+    "zh:f6844cf7ead4443638dfdb3f837481585f4a4c910bcf7b030a19820cc5109ebc",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = ">= 2.5.0, < 2.18.0"
+  hashes = [
+    "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = ">= 2.10.0, < 2.39.0"
+  hashes = [
+    "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.1, < 3.10.0"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/kubernetes/examples/simple/README.md
+++ b/kubernetes/examples/simple/README.md
@@ -12,7 +12,7 @@ This example deploys self-managed Materialize onto a Kubernetes cluster you alre
 
 - A Kubernetes cluster and a kubeconfig that reaches it
 - **Metadata backend**: a PostgreSQL database, passed as `metadata_backend_url`
-- **Persist backend**: an S3-compatible object store (S3, MinIO, GCS interop, ...), passed as `persist_backend_url`
+- **Persist backend**: an S3-compatible object store (S3, RustFS, GCS interop, ...), passed as `persist_backend_url`
 - A Materialize license key
 
 The instance's clusters schedule onto nodes labeled `materialize.cloud/swap=true` by default (see the chart's `clusterd.swapNodeSelector`), so label the nodes Materialize should run on accordingly.

--- a/kubernetes/examples/simple/README.md
+++ b/kubernetes/examples/simple/README.md
@@ -1,0 +1,38 @@
+# Example: Simple Materialize Deployment on an Existing Kubernetes Cluster
+
+This example deploys self-managed Materialize onto a Kubernetes cluster you already have -- on-prem, bare-metal, a local [kind](https://kind.sigs.k8s.io/) cluster, or any managed cluster -- using only a kubeconfig. Unlike the `aws/`, `azure/`, and `gcp/` examples, it provisions no cloud infrastructure.
+
+## What Gets Created
+
+- **cert-manager** and a **self-signed ClusterIssuer** for TLS between Materialize components
+- **Materialize operator** (`orchestratord`), installed from the [Helm chart](https://materializeinc.github.io/materialize/) into the `materialize` namespace, with the v1 CRD and its conversion webhook enabled
+- **Materialize instance** (`main`) in the `materialize-environment` namespace, with password authentication for `mz_system`
+
+## What You Bring
+
+- A Kubernetes cluster and a kubeconfig that reaches it
+- **Metadata backend**: a PostgreSQL database, passed as `metadata_backend_url`
+- **Persist backend**: an S3-compatible object store (S3, MinIO, GCS interop, ...), passed as `persist_backend_url`
+- A Materialize license key
+
+The instance's clusters schedule onto nodes labeled `materialize.cloud/swap=true` by default (see the chart's `clusterd.swapNodeSelector`), so label the nodes Materialize should run on accordingly.
+
+## Usage
+
+```sh
+terraform init
+terraform apply \
+  -var 'license_key=...' \
+  -var 'metadata_backend_url=postgres://user:pass@postgres.example.com:5432/materialize' \
+  -var 'persist_backend_url=s3://user:pass@bucket/prefix?endpoint=https%3A%2F%2Fs3.example.com&region=us-east-1'
+```
+
+Once applied, connect via the balancerd service (no load balancer is created):
+
+```sh
+kubectl port-forward -n materialize-environment "svc/$(terraform output -raw balancerd_service_name)" 6875:6875
+PGPASSWORD="$(terraform output -raw external_login_password_mz_system)" \
+  psql "sslmode=require host=127.0.0.1 port=6875 user=mz_system dbname=materialize"
+```
+
+This example is also what the test harness deploys onto a kind cluster for local/CI integration testing -- see `test/README.md`.

--- a/kubernetes/examples/simple/main.tf
+++ b/kubernetes/examples/simple/main.tf
@@ -1,0 +1,79 @@
+# Self-managed Materialize on an existing Kubernetes cluster -- any cluster
+# reachable through a kubeconfig, without cloud-provider infrastructure. You
+# bring the two backends (PostgreSQL for metadata, S3-compatible storage for
+# persist) and pass their connection URLs as variables. The operator is
+# installed straight from the Helm chart, whose defaults already target a
+# local/generic deployment.
+
+module "cert_manager" {
+  source = "../../modules/cert-manager"
+}
+
+module "self_signed_cluster_issuer" {
+  source = "../../modules/self-signed-cluster-issuer"
+
+  name_prefix = var.name_prefix
+
+  depends_on = [module.cert_manager]
+}
+
+resource "helm_release" "materialize_operator" {
+  name             = "materialize-operator"
+  namespace        = "materialize"
+  create_namespace = true
+
+  repository = var.use_local_chart ? null : "https://materializeinc.github.io/materialize/"
+  chart      = var.helm_chart
+  version    = var.use_local_chart ? null : var.operator_version
+
+  values = [
+    yamlencode({
+      operator = merge(
+        # The materialize-instance module creates v1 CRs; the chart installs
+        # only v1alpha1 by default. The v1 conversion webhook needs a
+        # certificate from cert-manager.
+        { args = { installV1CRD = true } },
+        var.orchestratord_version == null ? {} : { image = { tag = var.orchestratord_version } },
+      )
+    })
+  ]
+
+  depends_on = [module.cert_manager]
+}
+
+resource "random_password" "external_login_password_mz_system" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+module "materialize_instance" {
+  source = "../../modules/materialize-instance"
+
+  instance_name        = "main"
+  instance_namespace   = "materialize-environment"
+  environmentd_version = var.environmentd_version
+  license_key          = var.license_key
+
+  metadata_backend_url = var.metadata_backend_url
+  persist_backend_url  = var.persist_backend_url
+
+  authenticator_kind                = "Password"
+  external_login_password_mz_system = random_password.external_login_password_mz_system.result
+
+  issuer_ref = {
+    name = module.self_signed_cluster_issuer.issuer_name
+    kind = "ClusterIssuer"
+  }
+
+  # The module's egress policies only allow kube-system and the API server,
+  # which cuts environmentd off from backends the cluster hosts itself or
+  # reaches on other ports. On enforcing CNIs, enable this together with the
+  # chart's networkPolicies values (see the cloud operator modules).
+  enable_network_policies = false
+
+  depends_on = [
+    helm_release.materialize_operator,
+    module.self_signed_cluster_issuer,
+  ]
+}

--- a/kubernetes/examples/simple/outputs.tf
+++ b/kubernetes/examples/simple/outputs.tf
@@ -1,0 +1,22 @@
+output "materialize_instance_name" {
+  description = "Materialize instance name"
+  value       = module.materialize_instance.instance_name
+}
+
+output "materialize_instance_namespace" {
+  description = "Materialize instance namespace"
+  value       = module.materialize_instance.instance_namespace
+}
+
+output "external_login_password_mz_system" {
+  description = "Password for the external login to the Materialize instance"
+  value       = random_password.external_login_password_mz_system.result
+  sensitive   = true
+}
+
+# There is no cloud load balancer here; reach SQL by port-forwarding this
+# service (port 6875) or by exposing it in whatever way fits your cluster.
+output "balancerd_service_name" {
+  description = "Name of the balancerd service for the Materialize instance"
+  value       = "mz${module.materialize_instance.instance_resource_id}-balancerd"
+}

--- a/kubernetes/examples/simple/variables.tf
+++ b/kubernetes/examples/simple/variables.tf
@@ -1,0 +1,65 @@
+variable "kubeconfig_path" {
+  description = "Path to the kubeconfig for the target cluster"
+  type        = string
+  default     = "~/.kube/config"
+}
+
+variable "kube_context" {
+  description = "Kubeconfig context to use. Null uses the current context."
+  type        = string
+  default     = null
+}
+
+variable "name_prefix" {
+  description = "Prefix for named resources"
+  type        = string
+  default     = "materialize"
+}
+
+variable "license_key" {
+  description = "Materialize license key"
+  type        = string
+  sensitive   = true
+}
+
+variable "metadata_backend_url" {
+  description = "PostgreSQL connection URL for the metadata backend, e.g. postgres://user:pass@host:5432/materialize"
+  type        = string
+  sensitive   = true
+}
+
+variable "persist_backend_url" {
+  description = "S3-compatible connection URL for the persist backend, e.g. s3://user:pass@bucket/prefix?endpoint=https%3A%2F%2Fhost&region=region"
+  type        = string
+  sensitive   = true
+}
+
+variable "operator_version" {
+  description = "Version of the Materialize operator Helm chart"
+  type        = string
+  default     = "v26.37.0" # META: helm-chart version
+}
+
+variable "helm_chart" {
+  description = "Chart name from repository or local path to chart. For local charts, set the path to the chart directory."
+  type        = string
+  default     = "materialize-operator"
+}
+
+variable "use_local_chart" {
+  description = "Whether to use a local chart instead of one from a repository"
+  type        = bool
+  default     = false
+}
+
+variable "orchestratord_version" {
+  description = "Orchestratord image tag override. Null uses the chart default."
+  type        = string
+  default     = null
+}
+
+variable "environmentd_version" {
+  description = "Environmentd version override. Null uses the materialize-instance module default."
+  type        = string
+  default     = null
+}

--- a/kubernetes/examples/simple/versions.tf
+++ b/kubernetes/examples/simple/versions.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10.0, < 2.39.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.5.0, < 2.18.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1, < 3.10.0"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "2.4.1"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path    = var.kubeconfig_path
+  config_context = var.kube_context
+}
+
+provider "helm" {
+  kubernetes {
+    config_path    = var.kubeconfig_path
+    config_context = var.kube_context
+  }
+}
+
+provider "kubectl" {
+  config_path    = var.kubeconfig_path
+  config_context = var.kube_context
+}

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,6 @@
 # Terraform Integration Tests
 
-End-to-end integration tests for the Materialize self-managed Terraform modules. The test harness deploys real infrastructure on AWS, Azure, or GCP, verifies that Materialize is running, and tears it down.
+End-to-end integration tests for the Materialize self-managed Terraform modules. The test harness deploys real infrastructure on AWS, Azure, or GCP, verifies that Materialize is running, and tears it down. It can also run entirely locally against a [kind](https://kind.sigs.k8s.io/) cluster -- see [Local kind runs](#local-kind-runs-self-managed).
 
 ## Prerequisites
 
@@ -30,6 +30,30 @@ cargo run -- run aws \
   --aws-region us-east-1 \
   --aws-profile my-profile
 ```
+
+## Local kind runs (self-managed)
+
+The `kind` provider runs the non-cloud-specific part of the test surface on your laptop, with no cloud credentials. It deploys `kubernetes/examples/simple` -- the customer-facing example for existing (non-cloud-managed) clusters -- onto a local kind cluster, with in-cluster PostgreSQL (metadata) and RustFS (persist) test backends from `test/kind/backends.yaml` standing in for the backends a customer would bring. This exercises the `kubernetes/` modules (`cert-manager`, `self-signed-cluster-issuer`, `materialize-instance`); the cloud-only modules (networking, managed clusters, load balancers, IAM, monitoring) are out of scope by construction and remain covered by the cloud providers.
+
+Additional prerequisites: Docker, `kind`, `kubectl`.
+
+```sh
+cargo run -- run kind --owner "Your Name" --license-key-file /path/to/license.key
+```
+
+`init` creates a kind cluster named after the test run ID (so kind runs coexist with any other kind clusters and with each other), writes its kubeconfig into the test run directory, and deploys the test backends; `apply` deploys the example into it with terraform; `verify` runs the same checks as the cloud providers, except that the node-local-dns/CoreDNS checks are skipped (kind keeps its stock DNS) and SQL connectivity goes through a `kubectl port-forward` to balancerd instead of a load balancer; `destroy` deletes the kind cluster.
+
+The staged workflow works as on the clouds, and is the fast path for iterating: keep the cluster up and re-run `verify` (or `sync` + `apply` after changing module code) without recreating anything:
+
+```sh
+cargo run -- init kind --owner "Your Name" --license-key-file key.txt
+# => Test run initialized successfully: t260319-a4bc2f
+cargo run -- apply --test-run t260319-a4bc2f
+cargo run -- verify --test-run t260319-a4bc2f   # repeatable
+cargo run -- destroy --test-run t260319-a4bc2f --rm
+```
+
+The dev overrides (`--local-chart-path`, `--orchestratord-version`, `--environmentd-version`) work with kind too, which makes it the cheapest way to smoke-test a local chart or new image version.
 
 ## Commands
 
@@ -164,6 +188,10 @@ The Materialize license key can be provided in three ways (in order of precedenc
 | `--resource-group-name` | Azure resource group name |
 | `--location` | Azure location (e.g. `westus2`) |
 
+### Kind
+
+No provider-specific arguments. Requires Docker and `kind` locally; the S3 backend options are accepted but unnecessary (state is small and local).
+
 ## Common arguments
 
 | Argument | Description | Default |
@@ -239,7 +267,11 @@ Same structure as AWS. Authenticates to GCP via Workload Identity Federation and
 
 Same structure as AWS. Authenticates to Azure via OIDC and to AWS via OIDC (for the S3 state backend). Skips if only AWS/GCP files changed.
 
-All three provider test workflows use `--destroy-on-failure` to ensure infrastructure is torn down even on test failure, and store Terraform state remotely in S3.
+### `test-kind.yml` -- Kind integration tests
+
+Runs the self-managed kind lifecycle (`cargo run -- run --destroy-on-failure kind`) on a plain GitHub-hosted runner. Needs no cloud credentials, only the `MATERIALIZE_LICENSE_KEY` secret. Currently `workflow_dispatch`/`workflow_call` only -- not wired into the merge queue until it has proven reliable there.
+
+All four test workflows use `--destroy-on-failure` to ensure infrastructure is torn down even on test failure; the three cloud workflows store Terraform state remotely in S3, while kind keeps state locally on the runner.
 
 ## Project layout
 
@@ -248,6 +280,9 @@ test/
   Cargo.toml
   README.md
   runs/              # test run directories (gitignored)
+  kind/
+    cluster.yaml     # kind cluster config (node labels for Materialize workloads)
+    backends.yaml    # in-cluster PostgreSQL/RustFS test backends
   src/
     main.rs          # CLI dispatch
     cli.rs           # argument definitions

--- a/test/kind/backends.yaml
+++ b/test/kind/backends.yaml
@@ -1,0 +1,147 @@
+# In-cluster stand-ins for the backends the kubernetes/examples/simple root
+# expects you to bring: PostgreSQL for metadata and RustFS (an S3-compatible
+# object store) for persist. Test fixtures only -- hardcoded credentials,
+# ephemeral storage. Applied by the harness right after the kind cluster is
+# created.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: backends
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: backends
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16
+          env:
+            - name: POSTGRES_DB
+              value: materialize
+            - name: POSTGRES_USER
+              value: materialize
+            - name: POSTGRES_PASSWORD
+              value: materialize
+          ports:
+            - containerPort: 5432
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "materialize"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: backends
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rustfs
+  namespace: backends
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rustfs
+  template:
+    metadata:
+      labels:
+        app: rustfs
+    spec:
+      containers:
+        - name: rustfs
+          image: rustfs/rustfs:1.0.0-beta.12-preview.1
+          env:
+            - name: RUSTFS_ACCESS_KEY
+              value: rustfsadmin
+            - name: RUSTFS_SECRET_KEY
+              value: rustfsadmin
+            - name: RUSTFS_ADDRESS
+              value: ":9000"
+            - name: RUSTFS_VOLUMES
+              value: /data
+          ports:
+            - containerPort: 9000
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 9000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rustfs
+  namespace: backends
+spec:
+  selector:
+    app: rustfs
+  ports:
+    - port: 9000
+      targetPort: 9000
+---
+# Creates the persist bucket; rustfs does not create buckets itself. Retries
+# inside the container until rustfs is up ("mb" on an existing bucket is an
+# error, so tolerate it via "ls").
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rustfs-setup
+  namespace: backends
+spec:
+  backoffLimit: 6
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: awscli
+          image: amazon/aws-cli:2.31.19
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: rustfsadmin
+            - name: AWS_SECRET_ACCESS_KEY
+              value: rustfsadmin
+            - name: AWS_DEFAULT_REGION
+              # rustfs ignores the region; the SDK requires one to sign.
+              value: us-east-1
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              ep=http://rustfs.backends.svc.cluster.local:9000
+              until aws --endpoint-url "$ep" s3 mb s3://materialize ||
+                    aws --endpoint-url "$ep" s3 ls s3://materialize; do
+                echo "waiting for rustfs..."; sleep 3
+              done

--- a/test/kind/cluster.yaml
+++ b/test/kind/cluster.yaml
@@ -1,0 +1,13 @@
+# Kind cluster configuration for the self-managed integration tests.
+# The node labels satisfy the operator's default node selectors for
+# swap-enabled clusterd pods (materialize.cloud/swap=true).
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "materialize.cloud/swap=true,materialize.cloud/disk=true,materialize.cloud/availability-zone=kind"

--- a/test/src/cli.rs
+++ b/test/src/cli.rs
@@ -195,6 +195,11 @@ pub enum InitProvider {
         #[arg(long)]
         region: String,
     },
+    /// Initialize a self-managed test run on a local kind cluster.
+    Kind {
+        #[clap(flatten)]
+        common: CommonInitArgs,
+    },
 }
 
 impl InitProvider {
@@ -203,6 +208,7 @@ impl InitProvider {
             InitProvider::Aws { .. } => CloudProvider::Aws,
             InitProvider::Azure { .. } => CloudProvider::Azure,
             InitProvider::Gcp { .. } => CloudProvider::Gcp,
+            InitProvider::Kind { .. } => CloudProvider::Kind,
         }
     }
 
@@ -210,7 +216,8 @@ impl InitProvider {
         match self {
             InitProvider::Aws { common, .. }
             | InitProvider::Azure { common, .. }
-            | InitProvider::Gcp { common, .. } => common,
+            | InitProvider::Gcp { common, .. }
+            | InitProvider::Kind { common } => common,
         }
     }
 

--- a/test/src/commands/destroy.rs
+++ b/test/src/commands/destroy.rs
@@ -3,12 +3,14 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use tokio::process::Command;
 
-use crate::helpers::{ci_log_group, delete_backend_state, run_cmd, write_lifecycle};
+use crate::helpers::{ci_log_group, delete_backend_state, read_tfvars, run_cmd, write_lifecycle};
+use crate::types::CloudProvider;
 
 const MAX_DESTROY_ATTEMPTS: u32 = 3;
 
-/// Runs `terraform destroy -auto-approve` in the test run directory.
-/// If `rm` is true, removes the directory afterwards.
+/// Tears down a test run: `terraform destroy -auto-approve` for the cloud
+/// providers, `kind delete cluster` for kind. If `rm` is true, removes the
+/// directory afterwards.
 ///
 /// Retries on transient failures. Orphaned ENI cleanup for AWS is
 /// handled by a destroy-time provisioner in the EKS Terraform module.
@@ -18,23 +20,20 @@ pub async fn phase_destroy(dir: &Path, rm: bool) -> Result<()> {
         println!("Destroying test run...");
         println!("  Directory: {}", dir.display());
 
-        for attempt in 1..=MAX_DESTROY_ATTEMPTS {
-            let result = run_cmd(
-                Command::new("terraform")
-                    .args(["destroy", "-auto-approve"])
-                    .current_dir(dir),
+        if read_tfvars(dir)?.cloud_provider() == CloudProvider::Kind {
+            // Everything a kind run creates lives in the kind cluster, so
+            // deleting the cluster replaces `terraform destroy`.
+            let cluster_name = dir.file_name().unwrap().to_string_lossy();
+            run_cmd(
+                Command::new("kind")
+                    .args(["delete", "cluster", "--name", &cluster_name])
+                    .arg("--kubeconfig")
+                    .arg(dir.join("kubeconfig")),
             )
-            .await;
-
-            match result {
-                Ok(()) => break,
-                Err(_) if attempt < MAX_DESTROY_ATTEMPTS => {
-                    println!(
-                        "\nDestroy attempt {attempt}/{MAX_DESTROY_ATTEMPTS} failed. Retrying...\n"
-                    );
-                }
-                Err(e) => return Err(e).context("terraform destroy failed after all attempts"),
-            }
+            .await
+            .context("kind delete cluster failed")?;
+        } else {
+            destroy_terraform(dir).await?;
         }
 
         if rm {
@@ -52,4 +51,27 @@ pub async fn phase_destroy(dir: &Path, rm: bool) -> Result<()> {
         Ok(())
     })
     .await
+}
+
+/// Runs `terraform destroy -auto-approve` with retries on transient failures.
+async fn destroy_terraform(dir: &Path) -> Result<()> {
+    for attempt in 1..=MAX_DESTROY_ATTEMPTS {
+        let result = run_cmd(
+            Command::new("terraform")
+                .args(["destroy", "-auto-approve"])
+                .current_dir(dir),
+        )
+        .await;
+
+        match result {
+            Ok(()) => break,
+            Err(_) if attempt < MAX_DESTROY_ATTEMPTS => {
+                println!(
+                    "\nDestroy attempt {attempt}/{MAX_DESTROY_ATTEMPTS} failed. Retrying...\n"
+                );
+            }
+            Err(e) => return Err(e).context("terraform destroy failed after all attempts"),
+        }
+    }
+    Ok(())
 }

--- a/test/src/commands/init.rs
+++ b/test/src/commands/init.rs
@@ -47,7 +47,10 @@ pub async fn phase_init(provider_args: &InitProvider) -> Result<PathBuf> {
             orchestratord_version: common.orchestratord_version.is_some(),
             environmentd_version: common.environmentd_version.is_some(),
         };
-        if overrides.any() {
+        // The kubernetes example (used by kind) declares these variables
+        // natively -- its operator is a helm_release, not a module -- so
+        // injection is neither needed nor possible there.
+        if overrides.any() && provider != CloudProvider::Kind {
             println!("\nApplying dev overrides...");
             write_dev_variables_tf(&dest).await?;
             inject_dev_overrides(&dest, &overrides).await?;
@@ -73,10 +76,30 @@ pub async fn phase_init(provider_args: &InitProvider) -> Result<PathBuf> {
 
         upload_tfvars_to_backend(&dest).await?;
 
+        // The cloud providers get their cluster from `terraform apply`; for
+        // kind the cluster is local infrastructure that terraform runs
+        // against, so it is created during init. After the tfvars are
+        // written, so a failed creation can still be cleaned up by `destroy`.
+        if provider == CloudProvider::Kind {
+            println!("\nCreating kind cluster {test_run_id}...");
+            create_kind_cluster(&test_run_id, &dest).await?;
+        }
+
         println!("\nRunning terraform init...");
-        run_cmd(Command::new("terraform").arg("init").current_dir(&dest))
+        let init_result = run_cmd(Command::new("terraform").arg("init").current_dir(&dest))
             .await
-            .context("terraform init failed")?;
+            .context("terraform init failed");
+        if let Err(e) = init_result {
+            // A failed init returns before `run --destroy-on-failure` gets a
+            // test run to destroy, so the just-created kind cluster would
+            // leak. Best-effort delete; the clouds have nothing to clean up.
+            if provider == CloudProvider::Kind {
+                run_cmd(Command::new("kind").args(["delete", "cluster", "--name", &test_run_id]))
+                    .await
+                    .ok();
+            }
+            return Err(e);
+        }
 
         write_lifecycle(&dest, "init", "completed").await?;
         println!("\nTest run initialized successfully: {test_run_id}");
@@ -184,8 +207,8 @@ fn build_tfvars(provider_args: &InitProvider, test_run_id: &str) -> Result<TfVar
     let common_tf = CommonTfVars {
         name_prefix: test_run_id.to_string(),
         license_key: common.resolve_license_key()?,
-        internal_load_balancer: false,
-        grafana_allow_public_access: true,
+        internal_load_balancer: internal_load_balancer(provider_args),
+        grafana_allow_public_access: grafana_allow_public_access(provider_args),
         helm_chart,
         use_local_chart,
         orchestratord_version: common.orchestratord_version.clone(),
@@ -193,6 +216,13 @@ fn build_tfvars(provider_args: &InitProvider, test_run_id: &str) -> Result<TfVar
     };
 
     Ok(match provider_args {
+        InitProvider::Kind { .. } => TfVars::Kind {
+            common: common_tf,
+            kubeconfig_path: "./kubeconfig".into(),
+            // The in-cluster backends from test/kind/backends.yaml.
+            metadata_backend_url: "postgres://materialize:materialize@postgres.backends.svc.cluster.local:5432/materialize?sslmode=disable".into(),
+            persist_backend_url: "s3://rustfsadmin:rustfsadmin@materialize/persist?endpoint=http%3A%2F%2Frustfs.backends.svc.cluster.local%3A9000&region=us-east-1".into(),
+        },
         InitProvider::Aws {
             aws_region,
             aws_profile,
@@ -409,4 +439,48 @@ fn var_ref(name: &str) -> hcl_edit::expr::Expression {
         )))],
     )
     .into()
+}
+
+/// The two load-balancer acknowledgements only exist as variables in the
+/// cloud roots; kind has no load balancers, so they are omitted from its
+/// tfvars entirely (terraform warns about unused tfvars values).
+fn internal_load_balancer(provider_args: &InitProvider) -> Option<bool> {
+    match provider_args {
+        InitProvider::Kind { .. } => None,
+        _ => Some(false),
+    }
+}
+
+fn grafana_allow_public_access(provider_args: &InitProvider) -> Option<bool> {
+    match provider_args {
+        InitProvider::Kind { .. } => None,
+        _ => Some(true),
+    }
+}
+
+/// Creates the kind cluster for a test run, writes its kubeconfig into the
+/// test run directory (where the copied terraform root expects it), and
+/// deploys the in-cluster PostgreSQL/RustFS backends the example needs.
+async fn create_kind_cluster(test_run_id: &str, dest: &Path) -> Result<()> {
+    let kind_dir = project_root()?.join("test/kind");
+    let kubeconfig = dest.join("kubeconfig");
+    run_cmd(
+        Command::new("kind")
+            .args(["create", "cluster", "--name", test_run_id, "--wait", "120s"])
+            .arg("--config")
+            .arg(kind_dir.join("cluster.yaml"))
+            .arg("--kubeconfig")
+            .arg(&kubeconfig),
+    )
+    .await
+    .context("kind create cluster failed")?;
+
+    run_cmd(
+        crate::helpers::kubectl(&kubeconfig)
+            .arg("apply")
+            .arg("-f")
+            .arg(kind_dir.join("backends.yaml")),
+    )
+    .await
+    .context("failed to deploy the kind test backends")
 }

--- a/test/src/commands/sync.rs
+++ b/test/src/commands/sync.rs
@@ -8,6 +8,7 @@ use crate::commands::init::{
 use crate::helpers::{
     ci_log_group, example_dir, project_root, read_tfvars, upload_tfvars_to_backend,
 };
+use crate::types::CloudProvider;
 
 /// Re-copies example .tf files into an existing test run directory,
 /// overwriting the current versions. Useful for picking up local
@@ -42,7 +43,10 @@ pub async fn phase_sync(dir: &Path) -> Result<()> {
             orchestratord_version: common.orchestratord_version.is_some(),
             environmentd_version: common.environmentd_version.is_some(),
         };
-        if overrides.any() {
+        // The kubernetes example (used by kind) declares the dev-override
+        // variables natively, so no injection is needed (or possible: its
+        // operator is a helm_release, not a module).
+        if overrides.any() && provider != CloudProvider::Kind {
             println!("\nRe-applying dev overrides...");
             write_dev_variables_tf(dir).await?;
             inject_dev_overrides(dir, &overrides).await?;

--- a/test/src/commands/verify.rs
+++ b/test/src/commands/verify.rs
@@ -37,7 +37,12 @@ pub async fn phase_verify(dir: &Path) -> Result<()> {
         verify_materialize_instance(&kubeconfig, instance_namespace, instance_name).await?;
 
         println!("\nVerifying pods in namespace {instance_namespace}...");
-        verify_pods_running(&kubeconfig, instance_namespace).await?;
+        if let Err(e) = verify_pods_running(&kubeconfig, instance_namespace).await {
+            // The retry log only shows counts; the describe output has the
+            // scheduling events explaining why a pod never became Running.
+            dump_materialize_diagnostics(&kubeconfig, instance_namespace, instance_name).await;
+            return Err(e);
+        }
 
         if let Some(version) = tfvars.common().environmentd_version.as_deref() {
             println!("\nVerifying environmentd is running version {version}...");
@@ -50,7 +55,11 @@ pub async fn phase_verify(dir: &Path) -> Result<()> {
         println!("\nVerifying the default DNS deployments were scaled down...");
         verify_default_dns_scaled_down(&kubeconfig, provider).await?;
 
-        if let Some(endpoint) = outputs.load_balancer_endpoint() {
+        if provider == CloudProvider::Kind {
+            println!("\nVerifying Materialize SQL connectivity via port-forward...");
+            verify_sql_connection_via_port_forward(&kubeconfig, instance_namespace, &outputs)
+                .await?;
+        } else if let Some(endpoint) = outputs.load_balancer_endpoint() {
             println!("\nVerifying Materialize SQL connectivity at {endpoint}...");
             verify_sql_connection(endpoint, &outputs).await?;
         } else {
@@ -71,8 +80,23 @@ async fn setup_kubeconfig(
     outputs: &TerraformOutputs,
 ) -> Result<PathBuf> {
     let kubeconfig = dir.join("kubeconfig");
-    let cluster_name = outputs.cluster_name(provider)?;
+    // The kind cluster is named after the test run rather than a terraform
+    // output, since terraform does not create it.
+    let cluster_name = match provider {
+        CloudProvider::Kind => dir.file_name().unwrap().to_string_lossy().into_owned(),
+        _ => outputs.cluster_name(provider)?.to_string(),
+    };
+    let cluster_name = cluster_name.as_str();
     match tfvars {
+        TfVars::Kind { .. } => {
+            run_cmd(
+                Command::new("kind")
+                    .args(["export", "kubeconfig", "--name", cluster_name])
+                    .arg("--kubeconfig")
+                    .arg(&kubeconfig),
+            )
+            .await?;
+        }
         TfVars::Aws {
             aws_region,
             aws_profile,
@@ -335,9 +359,16 @@ async fn verify_environmentd_image(
 /// node-local-dns helm module on AWS and by the NodeLocal DNSCache addon on
 /// GCP; AKS has no supported node-local DNS option (see azure/README.md).
 async fn verify_node_local_dns(kubeconfig: &Path, provider: CloudProvider) -> Result<()> {
-    if matches!(provider, CloudProvider::Azure) {
-        println!("  Skipping node-local-dns check (not supported on AKS).");
-        return Ok(());
+    match provider {
+        CloudProvider::Azure => {
+            println!("  Skipping node-local-dns check (not supported on AKS).");
+            return Ok(());
+        }
+        CloudProvider::Kind => {
+            println!("  Skipping node-local-dns check (not deployed on kind).");
+            return Ok(());
+        }
+        _ => {}
     }
 
     const MAX_ATTEMPTS: u32 = 10;
@@ -383,6 +414,8 @@ fn scaled_down_dns_deployments(provider: CloudProvider) -> &'static [&'static st
         CloudProvider::Aws => &["coredns"],
         CloudProvider::Gcp => &["kube-dns", "kube-dns-autoscaler"],
         CloudProvider::Azure => &["coredns", "coredns-autoscaler"],
+        // kind keeps its stock CoreDNS; the coredns module is not applied.
+        CloudProvider::Kind => &[],
     }
 }
 
@@ -428,6 +461,96 @@ async fn verify_default_dns_scaled_down(kubeconfig: &Path, provider: CloudProvid
     Ok(())
 }
 
+/// SQL connectivity check for kind, where there is no load balancer: forwards
+/// a local port to the balancerd service and connects through it.
+///
+/// The whole tunnel is set up fresh on every attempt: balancerd can be Running
+/// but not yet Ready (no service endpoints, so port-forward fails
+/// immediately), and an established tunnel dies if kubectl loses the pod
+/// connection.
+async fn verify_sql_connection_via_port_forward(
+    kubeconfig: &Path,
+    namespace: &str,
+    outputs: &TerraformOutputs,
+) -> Result<()> {
+    let service = outputs
+        .balancerd_service_name
+        .as_ref()
+        .map(|o| o.value.as_str())
+        .context("Missing terraform output: balancerd_service_name")?;
+    let password = outputs.mz_password()?;
+
+    const MAX_ATTEMPTS: u32 = 20;
+    const INTERVAL: std::time::Duration = std::time::Duration::from_secs(15);
+
+    let output = retry(
+        MAX_ATTEMPTS,
+        INTERVAL,
+        |attempt, err| {
+            println!(
+                "  Attempt {attempt}/{MAX_ATTEMPTS}: {err:#}, retrying in {}s...",
+                INTERVAL.as_secs()
+            );
+        },
+        || async {
+            let (mut child, port) = spawn_port_forward(kubeconfig, namespace, service).await?;
+            let result = sql_select_1("127.0.0.1", port, password).await;
+            child.kill().await.ok();
+            result
+        },
+    )
+    .await
+    .context("Failed to connect to Materialize via SQL after all retries")?;
+
+    println!("  SQL query succeeded: {output}");
+    Ok(())
+}
+
+/// Spawns `kubectl port-forward` to the given service's SQL port and returns
+/// the child process along with the local port. Port 0 lets the kernel pick a
+/// free local port, which kubectl reports on stdout.
+async fn spawn_port_forward(
+    kubeconfig: &Path,
+    namespace: &str,
+    service: &str,
+) -> Result<(tokio::process::Child, u16)> {
+    use tokio::io::{AsyncBufReadExt, BufReader};
+
+    let mut child = kubectl(kubeconfig)
+        .args([
+            "port-forward",
+            &format!("svc/{service}"),
+            "0:6875",
+            "-n",
+            namespace,
+        ])
+        .stdout(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .context("Failed to spawn kubectl port-forward")?;
+
+    // First line looks like: "Forwarding from 127.0.0.1:52341 -> 6875".
+    // Borrow stdout rather than take it: dropping the pipe would kill
+    // kubectl with EPIPE as soon as it writes its next line.
+    let stdout = child
+        .stdout
+        .as_mut()
+        .context("port-forward has no stdout")?;
+    let mut lines = BufReader::new(stdout).lines();
+    let line = tokio::time::timeout(std::time::Duration::from_secs(60), lines.next_line())
+        .await
+        .context("Timed out waiting for kubectl port-forward to start")??
+        .context("kubectl port-forward exited without output")?;
+    let port: u16 = line
+        .split(" -> ")
+        .next()
+        .and_then(|addr| addr.rsplit(':').next())
+        .and_then(|p| p.parse().ok())
+        .with_context(|| format!("Could not parse port-forward output: {line}"))?;
+    println!("  Forwarding 127.0.0.1:{port} to {service}:6875");
+    Ok((child, port))
+}
+
 async fn verify_sql_connection(endpoint: &str, outputs: &TerraformOutputs) -> Result<()> {
     let password = outputs.mz_password()?;
 
@@ -443,31 +566,34 @@ async fn verify_sql_connection(endpoint: &str, outputs: &TerraformOutputs) -> Re
                 INTERVAL.as_secs()
             );
         },
-        || async {
-            run_cmd_output(
-                Command::new("psql")
-                    .args([
-                        "-h",
-                        endpoint,
-                        "-p",
-                        "6875",
-                        "-U",
-                        "mz_system",
-                        "-d",
-                        "materialize",
-                        "-c",
-                        "SELECT 1",
-                    ])
-                    .env("PGPASSWORD", password)
-                    .env("PGCONNECT_TIMEOUT", "30")
-                    .env("PGSSLMODE", "require"),
-            )
-            .await
-        },
+        || sql_select_1(endpoint, 6875, password),
     )
     .await
     .context("Failed to connect to Materialize via SQL after all retries")?;
 
     println!("  SQL query succeeded: {output}");
     Ok(())
+}
+
+/// A single `SELECT 1` against Materialize via psql.
+async fn sql_select_1(host: &str, port: u16, password: &str) -> Result<String> {
+    run_cmd_output(
+        Command::new("psql")
+            .args([
+                "-h",
+                host,
+                "-p",
+                &port.to_string(),
+                "-U",
+                "mz_system",
+                "-d",
+                "materialize",
+                "-c",
+                "SELECT 1",
+            ])
+            .env("PGPASSWORD", password)
+            .env("PGCONNECT_TIMEOUT", "30")
+            .env("PGSSLMODE", "require"),
+    )
+    .await
 }

--- a/test/src/types.rs
+++ b/test/src/types.rs
@@ -1,17 +1,20 @@
 use std::collections::HashMap;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
 // Cloud provider
 // ---------------------------------------------------------------------------
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CloudProvider {
     Aws,
     Azure,
     Gcp,
+    /// A local kind cluster running the self-managed configuration. Not a
+    /// cloud: no cloud credentials, load balancers, or managed backends.
+    Kind,
 }
 
 impl CloudProvider {
@@ -20,6 +23,8 @@ impl CloudProvider {
             CloudProvider::Aws => "aws",
             CloudProvider::Azure => "azure",
             CloudProvider::Gcp => "gcp",
+            // kind deploys the cloud-independent kubernetes/ example.
+            CloudProvider::Kind => "kubernetes",
         }
     }
 }
@@ -32,12 +37,16 @@ impl CloudProvider {
 pub struct CommonTfVars {
     pub name_prefix: String,
     pub license_key: String,
-    pub internal_load_balancer: bool,
+    /// Cloud-only; `None` (omitted) for kind, which has no load balancers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub internal_load_balancer: Option<bool>,
     /// The test clusters are ephemeral and the runner needs a public address to
     /// reach Materialize, which means `0.0.0.0/0` on a public load balancer. The
     /// monitoring module refuses that for Grafana specifically, so the test roots
-    /// acknowledge it here. The examples leave it `false`.
-    pub grafana_allow_public_access: bool,
+    /// acknowledge it here. The examples leave it `false`. Cloud-only; `None`
+    /// (omitted) for kind.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grafana_allow_public_access: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub helm_chart: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -76,6 +85,16 @@ pub enum TfVars {
         region: String,
         labels: HashMap<String, String>,
     },
+    #[serde(rename = "kind")]
+    Kind {
+        #[serde(flatten)]
+        common: CommonTfVars,
+        /// Relative to the run directory, where init writes it.
+        kubeconfig_path: String,
+        /// The in-cluster backends from test/kind/backends.yaml.
+        metadata_backend_url: String,
+        persist_backend_url: String,
+    },
 }
 
 impl TfVars {
@@ -84,6 +103,7 @@ impl TfVars {
             TfVars::Aws { .. } => CloudProvider::Aws,
             TfVars::Azure { .. } => CloudProvider::Azure,
             TfVars::Gcp { .. } => CloudProvider::Gcp,
+            TfVars::Kind { .. } => CloudProvider::Kind,
         }
     }
 
@@ -91,7 +111,8 @@ impl TfVars {
         match self {
             TfVars::Aws { common, .. }
             | TfVars::Azure { common, .. }
-            | TfVars::Gcp { common, .. } => common,
+            | TfVars::Gcp { common, .. }
+            | TfVars::Kind { common, .. } => common,
         }
     }
 
@@ -99,7 +120,8 @@ impl TfVars {
         match self {
             TfVars::Aws { common, .. }
             | TfVars::Azure { common, .. }
-            | TfVars::Gcp { common, .. } => common,
+            | TfVars::Gcp { common, .. }
+            | TfVars::Kind { common, .. } => common,
         }
     }
 }
@@ -133,6 +155,10 @@ pub struct TerraformOutputs {
 
     #[serde(default)]
     pub external_login_password_mz_system: Option<TfOutput<String>>,
+
+    /// kind only: the balancerd service verify port-forwards to reach SQL.
+    #[serde(default)]
+    pub balancerd_service_name: Option<TfOutput<String>>,
 }
 
 impl TerraformOutputs {
@@ -141,6 +167,8 @@ impl TerraformOutputs {
             CloudProvider::Aws => &self.eks_cluster_name,
             CloudProvider::Gcp => &self.gke_cluster_name,
             CloudProvider::Azure => &self.aks_cluster_name,
+            // The kind cluster is named after the test run, not a terraform output.
+            CloudProvider::Kind => bail!("kind clusters have no cluster name output"),
         };
         output
             .as_ref()


### PR DESCRIPTION
Linear issue: https://linear.app/materializeinc/issue/CLO-213/enable-self-managed-materialize-to-run-non-cloud-specific-module-tests

## Issue

Exercising the non-cloud-specific test surface (operator install, Materialize instance lifecycle, cert-manager/TLS wiring, SQL connectivity) previously required a full cloud deployment. This ports the kind-based flow from #121 to the rust test harness.

## Solution

Two commits:

1. **`kubernetes/examples/simple`** — a customer-facing example, symmetric with the cloud `examples/simple` roots, that deploys self-managed Materialize onto any existing cluster via a kubeconfig: cert-manager + self-signed issuer + the operator from the Helm chart (v1 CRD enabled) + a Materialize instance. The customer brings the metadata (PostgreSQL) and persist (S3-compatible) backends as connection-URL variables. Validated in the lint example matrix.
2. **A `kind` provider in the test harness** that deploys that example onto a local kind cluster, with the same lifecycle and ergonomics as the clouds:

```sh
cargo run -- run kind --owner "Your Name" --license-key-file key.txt
```

`init` creates a per-run kind cluster and deploys in-cluster PostgreSQL/RustFS test backends (`test/kind/backends.yaml`); `apply` deploys the example pointed at them via tfvars; `verify` runs the same checks as the clouds except the DNS ones, reaching SQL via `kubectl port-forward` to balancerd; `destroy` deletes the cluster. Iterating = keep the cluster, re-run `verify` (or `sync` + `apply`). Dev overrides (`--local-chart-path`, `--orchestratord-version`, `--environmentd-version`) work on kind, making it the cheapest way to smoke-test a local chart or image. Docs in `test/README.md`.

**CI decision:** `test-kind.yml` runs the full lifecycle but is `workflow_dispatch`/`workflow_call` only — deferred from the merge queue until proven reliable. It needs the `MATERIALIZE_LICENSE_KEY` secret and a `ubuntu-24.04-16core` runner (the stack's default resource requests don't fit a standard 4-CPU runner; the repo was granted access to the org's larger-runner group).

## Testing

- `cargo fmt/clippy -D warnings/deny`, `terraform fmt`, `tflint`, `terraform validate` all clean.
- Full lifecycle (`run kind`) passed end to end **locally** with a valid license key and **in CI** via workflow dispatch on this branch: instance UpToDate, all expected pods Running, `SELECT 1` through the port-forward, clean destroy.

## Gotchas for the reviewer

- The example sets `enable_network_policies = false` on materialize-instance: the module's egress allow-list only covers kube-system and the API server, which cuts environmentd off from backends the cluster hosts itself — recent kind versions *do* enforce NetworkPolicies, and the E2E run caught this. Enforcing-CNI users should enable it together with the chart's `networkPolicies` values (as the cloud operator modules do).
- The port-forward child's stdout must stay open for its lifetime (kubectl dies of EPIPE otherwise); the SQL check re-tunnels on every retry.
- Unlike #121, no public `kubernetes/modules/operator` module is added; the example installs the chart with a plain `helm_release`, mirroring the public install docs.
- `internal_load_balancer` / `grafana_allow_public_access` in `CommonTfVars` became `Option<bool>` (omitted for kind); the serialized tfvars for the clouds are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
