### PR TITLE
examples: lock the Polis SCIM endpoint to Okta's egress ranges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ tests/.terraform.lock.hcl
 test/*/t[0-9]*-*/
 .github/setup/*/terraform.tfstate
 .github/setup/*/backend-override.tf
+
+# Okta SCIM source-range allowlists are generated per Okta cell
+**/okta-scim-source-ranges.json

--- a/gcp/examples/enterprise/README.md
+++ b/gcp/examples/enterprise/README.md
@@ -44,6 +44,14 @@ OKTA_SAML_METADATA=~/Downloads/metadata.xml \
 
 It registers (or re-reads, idempotently) the connection and directory, then prints the `upstream_oidc_providers` block to add to `terraform.tfvars` and the remaining Okta admin-console steps.
 
+**Locking down the Polis endpoint (optional).** Okta pushes SCIM provisioning to Polis server-to-server, so the Polis LoadBalancer can stay public but firewalled to Okta's egress ranges. Generate the ranges for your Okta cell and re-apply:
+
+```sh
+./scripts/update-okta-ip-ranges.sh gcp/examples/enterprise <your-okta-cell>
+```
+
+That writes `okta-scim-source-ranges.json`, which the example reads into the Polis LB's `loadBalancerSourceRanges`. Set `ory_polis_source_ranges` to your VPC / VPN / tailnet CIDRs as well, since the browser reaches Polis directly for the SAML and OIDC hops. Only enable this when browser access to Ory is internal; a fully public browser flow needs Polis reachable from anywhere, so leave both unset (the default) to keep Polis unrestricted.
+
 ---
 
 ## Getting Started

--- a/gcp/examples/enterprise/main.tf
+++ b/gcp/examples/enterprise/main.tf
@@ -193,6 +193,11 @@ locals {
 
   ory_namespace = "ory"
 
+  # Okta's SCIM egress ranges (generate with scripts/update-okta-ip-ranges.sh),
+  # plus any operator internal/VPN ranges, applied as the Polis LB allowlist.
+  okta_scim_source_ranges = fileexists("${path.module}/okta-scim-source-ranges.json") ? jsondecode(file("${path.module}/okta-scim-source-ranges.json")) : []
+  polis_lb_source_ranges  = concat(local.okta_scim_source_ranges, var.ory_polis_source_ranges)
+
   # cert-manager ClusterIssuer for browser-facing TLS. Defaults to the built-in
   # self-signed issuer; override via var.cert_issuer_ref to plug in a real one.
   cert_issuer = var.cert_issuer_ref != null ? var.cert_issuer_ref : {
@@ -682,6 +687,12 @@ module "ory" {
   # external NLB otherwise.
   lb_annotations = var.internal_load_balancer ? {
     "networking.gke.io/load-balancer-type" = "Internal"
+  } : {}
+
+  # Lock the Polis LB to Okta's SCIM egress ranges plus your internal ranges,
+  # when ory_polis_source_ranges is set or okta-scim-source-ranges.json exists.
+  lb_overrides = length(local.polis_lb_source_ranges) > 0 ? {
+    polis = { source_ranges = local.polis_lb_source_ranges }
   } : {}
 
   node_selector = local.generic_node_labels

--- a/gcp/examples/enterprise/variables.tf
+++ b/gcp/examples/enterprise/variables.tf
@@ -158,6 +158,13 @@ variable "polis_helm_values" {
   default     = {}
 }
 
+variable "ory_polis_source_ranges" {
+  description = "Extra CIDRs, besides Okta's SCIM egress ranges from okta-scim-source-ranges.json, allowed to reach the Polis LoadBalancer. Set these to your VPC / VPN / tailnet ranges so the browser SAML and OIDC hops still work, since the browser reaches Polis directly. Combined with the Okta ranges and applied as loadBalancerSourceRanges. Leave empty to keep Polis unrestricted. Only lock Polis down when browser access to Ory is internal; a fully public browser flow needs Polis reachable from anywhere."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
 variable "materialize_console_fqdn" {
   description = "External hostname for the Materialize console. Used to construct the OAuth2 redirect URI. Example: materialize.internal.example.com"
   type        = string

--- a/scripts/update-okta-ip-ranges.sh
+++ b/scripts/update-okta-ip-ranges.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# Writes Okta's published egress IP ranges for a given cell to
+# <example-dir>/okta-scim-source-ranges.json, so Terraform can apply them as
+# loadBalancerSourceRanges on the Polis LoadBalancer.
+#
+# Why: Okta pushes SCIM provisioning server-to-server from its cloud (no browser
+# in the loop), so the Polis LB can stay public but firewalled to Okta's egress
+# ranges plus your own internal ranges. See ory_polis_source_ranges in the
+# example and the README "Locking down the Polis endpoint" section.
+#
+# Okta publishes ranges per cell; find yours in the Okta admin console
+# (Settings). The Materialize tenant is us_cell_14 (the default here).
+#
+#   ./scripts/update-okta-ip-ranges.sh gcp/examples/enterprise us_cell_14
+#
+set -eu
+
+OKTA_RANGES_URL="https://s3.amazonaws.com/okta-ip-ranges/ip_ranges.json"
+
+usage() {
+    echo "Usage: $0 <example-dir> [okta-cell]" >&2
+    echo "  example-dir  path to the enterprise example, e.g. gcp/examples/enterprise" >&2
+    echo "  okta-cell    your Okta cell (default: us_cell_14)" >&2
+    exit 1
+}
+
+[ $# -ge 1 ] || usage
+DIR="$1"
+CELL="${2:-us_cell_14}"
+
+[ -d "$DIR" ] || {
+    echo "no such directory: $DIR" >&2
+    exit 1
+}
+command -v curl >/dev/null 2>&1 || { echo "curl is required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
+
+OUT="$DIR/okta-scim-source-ranges.json"
+
+curl -sSf "$OKTA_RANGES_URL" | jq --arg cell "$CELL" '
+    .[$cell].ip_ranges
+    | if . == null then error("cell \($cell) not found in ip_ranges.json") else . end
+    | sort
+' > "$OUT"
+
+echo "Wrote $(jq length "$OUT") ranges for $CELL to $OUT"


### PR DESCRIPTION
Adds `scripts/update-okta-ip-ranges.sh`, which fetches Okta's published egress ranges for a given cell and writes `okta-scim-source-ranges.json`. The GCP enterprise example reads that into the Polis LoadBalancer's `loadBalancerSourceRanges` (via the module's `lb_overrides["polis"].source_ranges`), plus a new `ory_polis_source_ranges` var for your own VPC / VPN / tailnet CIDRs.

Ported from the equivalent setup in mz-context-graph. Opt-in and off by default: with no ranges file and an empty var, Polis stays unrestricted.

One caveat worth a look in review: this only fits deployments where browser access to Ory is internal (VPC / tailnet), because the browser hits Polis directly for the SAML ACS and OIDC-authorize hops, only Okta's SCIM push is server-to-server. For a fully public browser flow, Polis has to stay reachable from anywhere, so you'd leave this off. Wired on GCP for now; aws/azure can adopt the same `lb_overrides` pattern.